### PR TITLE
(release) 1.3.7

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,8 @@ REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_PASSWORD=
 REDIS_DB=0
+
+################### Slack Configuration ###################
+SLACK_ENABLE=false
+SLACK_BOT_TOKEN=
+SLACK_CHANNEL=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Allowed `-` in platform name.
 - Added `Slack` notifications.
 - Added required parameter validation for `app_name` and `channel` in `FetchLatestVersionOfApp` endpoint. Returns an error if either parameter is missing.
+- Added a database connection check to the health check.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Added `binary` app support.
 - Allowed `-` in platform name.
 
+### Bug Fixes
+
+- Added validateParams to Update\Create app/channel/platform/arch
+
 ## v1.3.6
 
 ### Important Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 - Added `binary` app support.
+- Allowed `-` in platform name.
 
 ## v1.3.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@
 ### Features
 - Added `binary` app support.
 - Allowed `-` in platform name.
+- Added `Slack` notifications.
+- Added required parameter validation for `app_name` and `channel` in `FetchLatestVersionOfApp` endpoint. Returns an error if either parameter is missing.
 
 ### Bug Fixes
 
 - Added validateParams to Update\Create app/channel/platform/arch
+- Fixed an issue with `CheckLatestVersion` where cached metadata values persisted across calls, by moving `appMeta`, `channelMeta`, `platformMeta`, and `archMeta` to local variables.
 
 ## v1.3.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.3.7
+
+### Features
+- Added `binary` app support.
+
 ## v1.3.6
 
 ### Important Notes

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ The tests verify the implemented API using a test database and an existing S3 bu
     - TestUpdateApp
     - TestUpdatePlatform
     - TestUpdateArch
+    - TestFailedUpdatePlatform (expected result from API "400")
+    - TestChannelCreateWithWrongName (expected result from API "400")
     
 ## Create new migrations
 Install migrate tool [here](https://github.com/golang-migrate/migrate/blob/master/cmd/migrate/README.md).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,5 +9,5 @@
 - Add application code signing functionality for avoiding "Unknown Publisher" warnings 
 - Add "Forgot password" feature
 - Add email support
-- Add slack notifications
+- ~~Add slack notifications~~
 - Create SDKs

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,3 +10,4 @@
 - Add "Forgot password" feature
 - Add email support
 - Add slack notifications
+- Create SDKs

--- a/docker-compose/envs/backend.env
+++ b/docker-compose/envs/backend.env
@@ -10,3 +10,8 @@ MONGODB_URL=mongodb://root:MheCk6sSKB1m4xKNw5I@172.25.0.4/cb_faynosync_db?authSo
 API_KEY=UHp3aKb40fwpoKZluZByWQ
 MONGODB_URL_TESTS=mongodb://root:MheCk6sSKB1m4xKNw5I@172.25.0.4/cb_faynosync_db_tests?authSource=admin
 JWT_SECRET=MdnaDEXKy9nOc4beIvNcgyBjjctVsoSg4FKkT81VKt18
+PERFORMANCE_MODE=false
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_PASSWORD=
+REDIS_DB=0

--- a/examples/ci-cd/README.md
+++ b/examples/ci-cd/README.md
@@ -1,0 +1,17 @@
+# CI/CD Example: Github Actions
+This workflow is an example of a CI/CD pipeline for building a Rust application on multiple platforms and uploading assets to `faynoSync`. The workflow updates the version in `Cargo.toml` based on the input provided and handles authentication with faynoSync.
+
+## Prerequisites
+You need to create two secrets in your GitHub repository:
+
+- `USERNAME`: Your faynoSync username.
+
+- `PASSWORD`: Your faynoSync password.
+
+## Trigger
+Manual Dispatch (workflow_dispatch): Requires a `VERSION` input to set in the `Cargo.toml` file.
+
+### Command example
+```
+gh workflow run "Build app and upload assets to faynoSync" --ref branch_name --repo github.com/owner_name/repo_name -f VERSION="0.2.5-6"
+```

--- a/examples/ci-cd/gh-actions.yml
+++ b/examples/ci-cd/gh-actions.yml
@@ -1,0 +1,171 @@
+name: Build app and upload assets to faynoSync
+on:
+  workflow_dispatch:
+    inputs:
+      VERSION:
+        description: "The version to set in Cargo.toml"
+        required: true
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-20.04, ubuntu-latest, windows-latest, macos-latest ]
+    name: Building, ${{ matrix.os }}
+    steps:
+
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install toolchain
+        id: rust-toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install protoc
+        uses: taiki-e/install-action@v2
+        with:
+          tool: protoc
+
+      - name: Login and get token
+        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'windows-latest' || matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest'
+        id: login
+        shell: bash
+        run: |
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            sudo apt-get update && sudo apt-get install -y jq
+          elif [[ "$RUNNER_OS" == "Windows" ]]; then
+            choco install jq
+          elif [[ "$RUNNER_OS" == "macOS" ]]; then
+            brew install jq
+          fi
+    
+          response=$(curl -s -X POST -H "Content-Type: application/json" \
+            -d "{\"username\": \"${{ secrets.USERNAME }}\", \"password\": \"${{ secrets.PASSWORD }}\"}" \
+            https://faynosync.example.com/login)
+    
+          echo "Response: $response"
+    
+          token=$(echo $response | jq -r '.token')
+    
+          if [ "$token" == "null" ]; then
+            echo "Failed to retrieve token. Check your username and password."
+            exit 1
+          fi
+    
+          echo "TOKEN=$token" >> $GITHUB_ENV
+    
+      - name: Debug - Print Token
+        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'windows-latest' || matrix.os == 'macos-latest' || matrix.os == 'ubuntu-latest'
+        run: |
+          echo "Printing token for debug purposes:"
+          echo $TOKEN
+
+
+      - name: Get version from Cargo.toml (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          (Get-Content Cargo.toml) | ForEach-Object { if (-not $done -and $_ -match 'version = ".*"') {$_ -replace 'version = ".*"', 'version = "${{ github.event.inputs.VERSION }}"'; $done = $true} else {$_} } | Set-Content Cargo.toml
+          Get-Content Cargo.toml 
+
+      - name: Update version in Cargo.toml (Linux)
+        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'ubuntu-latest'
+        run: |
+          sed -i '0,/version = ".*"/s/version = ".*"/version = "${{ github.event.inputs.VERSION }}"/' Cargo.toml
+          cat Cargo.toml 
+  
+      - name: Update version in Cargo.toml (macOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          sed -i '' '1,/version = "/s/version = ".*"/version = "${{ github.event.inputs.VERSION }}"/' Cargo.toml
+          cat Cargo.toml 
+
+      - name: Create bin directory
+        run: mkdir bin
+
+      - name: Build on Linux GNU
+        if: matrix.os == 'ubuntu-20.04'
+        run: |
+          cargo build --target=x86_64-unknown-linux-gnu --release
+          asset_name="testapp-linux-gnu-amd64"
+          strip ./target/x86_64-unknown-linux-gnu/release/testapp
+          mv ./target/x86_64-unknown-linux-gnu/release/testapp ./bin/${asset_name}
+
+      - name: Build on Linux musl
+        if: matrix.os == 'ubuntu-latest'
+        # We're using musl to make the binaries statically linked and portable
+        run: |
+          sudo apt-get install -y musl-tools
+          rustup target add x86_64-unknown-linux-musl
+          cargo build --target=x86_64-unknown-linux-musl --release
+          asset_name="testapp-linux-musl-amd64"
+          strip ./target/x86_64-unknown-linux-musl/release/testapp
+          mv ./target/x86_64-unknown-linux-musl/release/testapp ./bin/${asset_name}
+
+      - name: Build on Windows
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: |
+          cargo build --target=x86_64-pc-windows-msvc --release
+          asset_name="testapp-win64-amd64.exe"
+          mv ./target/x86_64-pc-windows-msvc/release/testapp.exe ./bin/${asset_name}
+
+      - name: Build on MacOS for x86_64
+        if: matrix.os == 'macos-latest'
+        run: |
+          rustup target add x86_64-apple-darwin
+          cargo build --target=x86_64-apple-darwin --release
+          asset_name="testapp-osx-amd64"
+          mv ./target/x86_64-apple-darwin/release/testapp ./bin/${asset_name}
+
+      - name: Build on MacOS for M1/2
+        if: matrix.os == 'macos-latest'
+        run: |
+          rustup target add aarch64-apple-darwin
+          cargo build --target=aarch64-apple-darwin --release
+          asset_name="testapp-osx-aarch64"
+          mv ./target/aarch64-apple-darwin/release/testapp ./bin/${asset_name}
+
+      - name: Upload Linux GNU build to faynoSync
+        if: matrix.os == 'ubuntu-20.04'
+        run: |
+          curl --location 'https://faynosync.example.com/upload' \
+            --header "Authorization: Bearer $TOKEN" \
+            --form "file=@./bin/testapp-linux-gnu-amd64" \
+            --form "data={\"app_name\":\"testapp\",\"version\":\"${{ github.event.inputs.VERSION }}\",\"channel\":\"stable\",\"publish\":true,\"critical\":false,\"platform\":\"linux-gnu\",\"arch\":\"amd64\",\"changelog\":\"\"}"
+
+      - name: Upload Linux Musl build to faynoSync
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          curl --location 'https://faynosync.example.com/upload' \
+            --header "Authorization: Bearer $TOKEN" \
+            --form "file=@./bin/testapp-linux-musl-amd64" \
+            --form "data={\"app_name\":\"testapp\",\"version\":\"${{ github.event.inputs.VERSION }}\",\"channel\":\"stable\",\"publish\":true,\"critical\":false,\"platform\":\"linux-musl\",\"arch\":\"amd64\",\"changelog\":\"\"}"
+
+      - name: Upload Windows build to faynoSync
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: |
+          curl --location 'https://faynosync.example.com/upload' \
+            --header "Authorization: Bearer $TOKEN" \
+            --form "file=@./bin/testapp-win64-amd64.exe" \
+            --form "data={\"app_name\":\"testapp\",\"version\":\"${{ github.event.inputs.VERSION }}\",\"channel\":\"stable\",\"publish\":true,\"critical\":false,\"platform\":\"windows\",\"arch\":\"amd64\",\"changelog\":\"\"}"
+
+      - name: Upload MacOS intel build to faynoSync
+        if: matrix.os == 'macos-latest'
+        run: |
+          curl --location 'https://faynosync.example.com/upload' \
+            --header "Authorization: Bearer $TOKEN" \
+            --form "file=@./bin/testapp-osx-amd64" \
+            --form "data={\"app_name\":\"testapp\",\"version\":\"${{ github.event.inputs.VERSION }}\",\"channel\":\"stable\",\"publish\":true,\"critical\":false,\"platform\":\"darwin\",\"arch\":\"amd64\",\"changelog\":\"\"}"
+
+      - name: Upload MacOS arm build to faynoSync
+        if: matrix.os == 'macos-latest'
+        run: |
+          curl --location 'https://faynosync.example.com/upload' \
+            --header "Authorization: Bearer $TOKEN" \
+            --form "file=@./bin/testapp-osx-aarch64" \
+            --form "data={\"app_name\":\"testapp\",\"version\":\"${{ github.event.inputs.VERSION }}\",\"channel\":\"stable\",\"publish\":true,\"critical\":false,\"platform\":\"darwin\",\"arch\":\"arm64\",\"changelog\":\"\"}"

--- a/faynoSync_test.go
+++ b/faynoSync_test.go
@@ -188,7 +188,8 @@ func TestSignUp(t *testing.T) {
 		handler.SignUp(c)
 	})
 
-	payload := `{"username": "admin", "password": "password", "api_key": "UHp3aKb40fwpoKZluZByWQ"}`
+	regKey := os.Getenv("API_KEY")
+	payload := fmt.Sprintf(`{"username": "admin", "password": "password", "api_key": "%s"}`, regKey)
 	req, err := http.NewRequest("POST", "/signup", bytes.NewBufferString(payload))
 	if err != nil {
 		t.Fatal(err)
@@ -299,13 +300,13 @@ func TestListApps(t *testing.T) {
 	router.Use(utils.AuthMiddleware())
 	w := httptest.NewRecorder()
 
-	// Define the route for the upload endpoint.
+	// Define the route for the /app/list endpoint.
 	handler := handler.NewAppHandler(client, appDB, mongoDatabase, redisClient, true)
 	router.GET("/app/list", func(c *gin.Context) {
 		handler.ListApps(c)
 	})
 
-	// Create a POST request for the upload endpoint.
+	// Create a POST request for the /app/list endpoint.
 	req, err := http.NewRequest("GET", "/app/list", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -402,7 +403,7 @@ func TestAppCreate(t *testing.T) {
 	router.Use(utils.AuthMiddleware())
 	w := httptest.NewRecorder()
 
-	// Define the handler for the /channel/create route
+	// Define the handler for the /app/create route
 	handler := handler.NewAppHandler(client, appDB, mongoDatabase, redisClient, true)
 	router.POST("/app/create", func(c *gin.Context) {
 		handler.CreateApp(c)
@@ -429,7 +430,7 @@ func TestAppCreate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Create a POST request to the /channel/create endpoint
+	// Create a POST request to the /app/create endpoint
 	req, err := http.NewRequest("POST", "/app/create", body)
 	if err != nil {
 		t.Fatal(err)
@@ -454,7 +455,7 @@ func TestAppCreate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Check for the presence of the "createChannelResult.Created" key in the response
+	// Check for the presence of the "createAppResult.Created" key in the response
 	id, idExists := response["createAppResult.Created"]
 	assert.True(t, idExists)
 	idTestappApp = id.(string)
@@ -468,7 +469,7 @@ func TestSecondaryAppCreate(t *testing.T) {
 	router.Use(utils.AuthMiddleware())
 	w := httptest.NewRecorder()
 
-	// Define the handler for the /channel/create route
+	// Define the handler for the /app/create route
 	handler := handler.NewAppHandler(client, appDB, mongoDatabase, redisClient, true)
 	router.POST("/app/create", func(c *gin.Context) {
 		handler.CreateApp(c)
@@ -495,7 +496,7 @@ func TestSecondaryAppCreate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Create a POST request to the /channel/create endpoint
+	// Create a POST request to the /app/create endpoint
 	req, err := http.NewRequest("POST", "/app/create", body)
 	if err != nil {
 		t.Fatal(err)
@@ -524,7 +525,7 @@ func TestUpload(t *testing.T) {
 	router.Use(utils.AuthMiddleware())
 	w := httptest.NewRecorder()
 
-	// Define the route for the upload endpoint.
+	// Define the route for the /upload endpoint.
 	handler := handler.NewAppHandler(client, appDB, mongoDatabase, redisClient, true)
 	router.POST("/upload", func(c *gin.Context) {
 		handler.UploadApp(c)
@@ -565,7 +566,7 @@ func TestUpload(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Create a POST request for the upload endpoint.
+	// Create a POST request for the /upload endpoint.
 	req, err := http.NewRequest("POST", "/upload", body)
 	if err != nil {
 		t.Fatal(err)
@@ -587,6 +588,7 @@ func TestUpload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	logrus.Infof("Response Body after unmarshaling: %+v", response)
 	// Check that the "token" key exists in the response.
 	id, idExists := response["uploadResult.Uploaded"]
 	assert.True(t, idExists)
@@ -602,7 +604,7 @@ func TestUploadDuplicateApp(t *testing.T) {
 	router.Use(utils.AuthMiddleware())
 	w := httptest.NewRecorder()
 
-	// Define the route for the upload endpoint.
+	// Define the route for the /upload endpoint.
 	handler := handler.NewAppHandler(client, appDB, mongoDatabase, redisClient, true)
 	router.POST("/upload", func(c *gin.Context) {
 		handler.UploadApp(c)
@@ -643,7 +645,7 @@ func TestUploadDuplicateApp(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Create a POST request for the upload endpoint.
+	// Create a POST request for the /upload endpoint.
 	req, err := http.NewRequest("POST", "/upload", body)
 	if err != nil {
 		t.Fatal(err)
@@ -671,13 +673,13 @@ func TestDeleteApp(t *testing.T) {
 	router.Use(utils.AuthMiddleware())
 	w := httptest.NewRecorder()
 
-	// Define the route for the upload endpoint.
+	// Define the route for the /apps/delete endpoint.
 	handler := handler.NewAppHandler(client, appDB, mongoDatabase, redisClient, true)
 	router.DELETE("/apps/delete", func(c *gin.Context) {
 		handler.DeleteSpecificVersionOfApp(c)
 	})
 
-	// Create a POST request for the upload endpoint.
+	// Create a POST request for the /apps/delete endpoint.
 	req, err := http.NewRequest("DELETE", "/apps/delete?id="+uploadedFirstApp, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -701,13 +703,13 @@ func TestListChannels(t *testing.T) {
 	router.Use(utils.AuthMiddleware())
 	w := httptest.NewRecorder()
 
-	// Define the route for the upload endpoint.
+	// Define the route for the /channel/list endpoint.
 	handler := handler.NewAppHandler(client, appDB, mongoDatabase, redisClient, true)
 	router.GET("/channel/list", func(c *gin.Context) {
 		handler.ListChannels(c)
 	})
 
-	// Create a POST request for the upload endpoint.
+	// Create a POST request for the /channel/list endpoint.
 	req, err := http.NewRequest("GET", "/channel/list", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -972,7 +974,7 @@ func TestUploadAppWithoutChannel(t *testing.T) {
 	router.Use(utils.AuthMiddleware())
 	w := httptest.NewRecorder()
 
-	// Define the route for the upload endpoint.
+	// Define the route for the /upload endpoint.
 	handler := handler.NewAppHandler(client, appDB, mongoDatabase, redisClient, true)
 	router.POST("/upload", func(c *gin.Context) {
 		handler.UploadApp(c)
@@ -1041,13 +1043,13 @@ func TestListPlatforms(t *testing.T) {
 	router.Use(utils.AuthMiddleware())
 	w := httptest.NewRecorder()
 
-	// Define the route for the upload endpoint.
+	// Define the route for the /platform/list endpoint.
 	handler := handler.NewAppHandler(client, appDB, mongoDatabase, redisClient, true)
 	router.GET("/platform/list", func(c *gin.Context) {
 		handler.ListPlatforms(c)
 	})
 
-	// Create a POST request for the upload endpoint.
+	// Create a POST request for the /platform/list endpoint.
 	req, err := http.NewRequest("GET", "/platform/list", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -1099,7 +1101,7 @@ func TestPlatformCreate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Create a POST request to the /channel/create endpoint
+	// Create a POST request to the /platform/create endpoint
 	req, err := http.NewRequest("POST", "/platform/create", body)
 	if err != nil {
 		t.Fatal(err)
@@ -1123,7 +1125,6 @@ func TestPlatformCreate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Check that the "token" key exists in the response.
 	id, idExists := response["createPlatformResult.Created"]
 	assert.True(t, idExists)
 	platformId = id.(string)
@@ -1161,7 +1162,7 @@ func TestSecondaryPlatformCreate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Create a POST request to the /channel/create endpoint
+	// Create a POST request to the /platform/create endpoint
 	req, err := http.NewRequest("POST", "/platform/create", body)
 	if err != nil {
 		t.Fatal(err)
@@ -1187,7 +1188,7 @@ func TestUploadAppWithoutPlatform(t *testing.T) {
 	router.Use(utils.AuthMiddleware())
 	w := httptest.NewRecorder()
 
-	// Define the route for the upload endpoint.
+	// Define the route for the /upload endpoint.
 	handler := handler.NewAppHandler(client, appDB, mongoDatabase, redisClient, true)
 	router.POST("/upload", func(c *gin.Context) {
 		handler.UploadApp(c)
@@ -1256,13 +1257,13 @@ func TestListArchs(t *testing.T) {
 	router.Use(utils.AuthMiddleware())
 	w := httptest.NewRecorder()
 
-	// Define the route for the upload endpoint.
+	// Define the route for the /arch/list endpoint.
 	handler := handler.NewAppHandler(client, appDB, mongoDatabase, redisClient, true)
 	router.GET("/arch/list", func(c *gin.Context) {
 		handler.ListArchs(c)
 	})
 
-	// Create a POST request for the upload endpoint.
+	// Create a POST request for the /arch/list endpoint.
 	req, err := http.NewRequest("GET", "/arch/list", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -1339,7 +1340,6 @@ func TestArchCreate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Check that the "token" key exists in the response.
 	id, idExists := response["createArchResult.Created"]
 	assert.True(t, idExists)
 	archId = id.(string)
@@ -1360,7 +1360,7 @@ func TestSecondaryArchCreate(t *testing.T) {
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
 
-	// Add a field for the channel to the form
+	// Add a field for the arch to the form
 	dataPart, err := writer.CreateFormField("data")
 	if err != nil {
 		t.Fatal(err)
@@ -1403,7 +1403,7 @@ func TestUploadAppWithoutArch(t *testing.T) {
 	router.Use(utils.AuthMiddleware())
 	w := httptest.NewRecorder()
 
-	// Define the route for the upload endpoint.
+	// Define the route for the /upload endpoint.
 	handler := handler.NewAppHandler(client, appDB, mongoDatabase, redisClient, true)
 	router.POST("/upload", func(c *gin.Context) {
 		handler.UploadApp(c)
@@ -1532,7 +1532,7 @@ func TestMultipleUpload(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			// Create a POST request for the upload endpoint with the current combination.
+			// Create a POST request for the /upload endpoint with the current combination.
 			req, err := http.NewRequest("POST", "/upload", body)
 			if err != nil {
 				t.Fatal(err)
@@ -1554,7 +1554,6 @@ func TestMultipleUpload(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			// Check that the "token" key exists in the response.
 			id, idExists := response["uploadResult.Uploaded"]
 			assert.True(t, idExists)
 
@@ -1582,13 +1581,13 @@ func TestUpdateSpecificApp(t *testing.T) {
 
 	router := gin.Default()
 	router.Use(utils.AuthMiddleware())
-	// Define the route for the upload endpoint.
+	// Define the route for the update endpoint.
 	handler := handler.NewAppHandler(client, appDB, mongoDatabase, redisClient, true)
 	router.POST("/apps/update", func(c *gin.Context) {
 		handler.UpdateSpecificApp(c)
 	})
 
-	// Create a file to upload (you can replace this with a test file path).
+	// Create a file to update (you can replace this with a test file path).
 	filePaths := []string{"LICENSE", "LICENSE"}
 	for _, filePath := range filePaths {
 		file, err := os.Open(filePath)
@@ -1610,7 +1609,7 @@ func TestUpdateSpecificApp(t *testing.T) {
 			{uploadedAppIDs[1], "0.0.2.137", "nightly", true, true, "universalPlatform", "universalArch", "### Changelog"},
 		}
 
-		// Iterate through the combinations and upload the file for each combination.
+		// Iterate through the combinations and update the file for each combination.
 		for _, combo := range combinations {
 			w := httptest.NewRecorder()
 			// Reset the request body for each iteration.
@@ -1624,7 +1623,7 @@ func TestUpdateSpecificApp(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			// Create a POST request for the upload endpoint with the current combination.
+			// Create a POST request for the update endpoint with the current combination.
 			dataPart, err := writer.CreateFormField("data")
 			if err != nil {
 				t.Fatal(err)
@@ -1671,13 +1670,13 @@ func TestSearch(t *testing.T) {
 	router.Use(utils.AuthMiddleware())
 	w := httptest.NewRecorder()
 
-	// Define the route for the upload endpoint.
+	// Define the route for the /search endpoint.
 	handler := handler.NewAppHandler(client, appDB, mongoDatabase, redisClient, true)
 	router.GET("/search", func(c *gin.Context) {
 		handler.GetAppByName(c)
 	})
 
-	// Create a POST request for the upload endpoint.
+	// Create a POST request for the /search endpoint.
 	req, err := http.NewRequest("GET", "/search?app_name=testapp", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -2123,7 +2122,7 @@ func TestMultipleDelete(t *testing.T) {
 	router := gin.Default()
 	router.Use(utils.AuthMiddleware())
 
-	// Define the route for the deleteApp endpoint.
+	// Define the route for the /apps/delete endpoint.
 	handler := handler.NewAppHandler(client, appDB, mongoDatabase, redisClient, true)
 	router.DELETE("/apps/delete", func(c *gin.Context) {
 		handler.DeleteSpecificVersionOfApp(c)
@@ -2219,13 +2218,13 @@ func TestListChannelsWhenExist(t *testing.T) {
 	router.Use(utils.AuthMiddleware())
 	w := httptest.NewRecorder()
 
-	// Define the route for the upload endpoint.
+	// Define the route for the /channel/list endpoint.
 	handler := handler.NewAppHandler(client, appDB, mongoDatabase, redisClient, true)
 	router.GET("/channel/list", func(c *gin.Context) {
 		handler.ListChannels(c)
 	})
 
-	// Create a POST request for the upload endpoint.
+	// Create a POST request for the /channel/list endpoint.
 	req, err := http.NewRequest("GET", "/channel/list", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -2273,13 +2272,13 @@ func TestDeleteNightlyChannel(t *testing.T) {
 	router.Use(utils.AuthMiddleware())
 	w := httptest.NewRecorder()
 
-	// Define the route for the upload endpoint.
+	// Define the route for the /channel/delete endpoint.
 	handler := handler.NewAppHandler(client, appDB, mongoDatabase, redisClient, true)
 	router.DELETE("/channel/delete", func(c *gin.Context) {
 		handler.DeleteChannel(c)
 	})
 
-	// Create a POST request for the upload endpoint.
+	// Create a DELETE request for the /channel/delete endpoint.
 	req, err := http.NewRequest("DELETE", "/channel/delete?id="+idNightlyChannel, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -2303,13 +2302,13 @@ func TestDeleteStableChannel(t *testing.T) {
 	router.Use(utils.AuthMiddleware())
 	w := httptest.NewRecorder()
 
-	// Define the route for the upload endpoint.
+	// Define the route for the /channel/delete endpoint.
 	handler := handler.NewAppHandler(client, appDB, mongoDatabase, redisClient, true)
 	router.DELETE("/channel/delete", func(c *gin.Context) {
 		handler.DeleteChannel(c)
 	})
 
-	// Create a POST request for the upload endpoint.
+	// Create a DELETE request for the /channel/delete endpoint.
 	req, err := http.NewRequest("DELETE", "/channel/delete?id="+idStableChannel, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -2332,7 +2331,7 @@ func TestUpdatePlatform(t *testing.T) {
 	router.Use(utils.AuthMiddleware())
 	w := httptest.NewRecorder()
 
-	// Define the handler for the /UpdatePlatform route
+	// Define the handler for the /platform/update route
 	handler := handler.NewAppHandler(client, appDB, mongoDatabase, redisClient, true)
 	router.POST("/platform/update", func(c *gin.Context) {
 		handler.UpdatePlatform(c)
@@ -2396,7 +2395,7 @@ func TestFailedUpdatePlatform(t *testing.T) {
 	router.Use(utils.AuthMiddleware())
 	w := httptest.NewRecorder()
 
-	// Define the handler for the /UpdatePlatform route
+	// Define the handler for the /platform/update route
 	handler := handler.NewAppHandler(client, appDB, mongoDatabase, redisClient, true)
 	router.POST("/platform/update", func(c *gin.Context) {
 		handler.UpdatePlatform(c)
@@ -2450,13 +2449,13 @@ func TestListPlatformsWhenExist(t *testing.T) {
 	router.Use(utils.AuthMiddleware())
 	w := httptest.NewRecorder()
 
-	// Define the route for the upload endpoint.
+	// Define the route for the /platform/list endpoint.
 	handler := handler.NewAppHandler(client, appDB, mongoDatabase, redisClient, true)
 	router.GET("/platform/list", func(c *gin.Context) {
 		handler.ListPlatforms(c)
 	})
 
-	// Create a POST request for the upload endpoint.
+	// Create a POST request for the /platform/list endpoint.
 	req, err := http.NewRequest("GET", "/platform/list", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -2501,13 +2500,13 @@ func TestDeletePlatform(t *testing.T) {
 	router.Use(utils.AuthMiddleware())
 	w := httptest.NewRecorder()
 
-	// Define the route for the upload endpoint.
+	// Define the route for the /platform/delete endpoint.
 	handler := handler.NewAppHandler(client, appDB, mongoDatabase, redisClient, true)
 	router.DELETE("/platform/delete", func(c *gin.Context) {
 		handler.DeletePlatform(c)
 	})
 
-	// Create a POST request for the upload endpoint.
+	// Create a DELETE request for the /platform/delete endpoint.
 	req, err := http.NewRequest("DELETE", "/platform/delete?id="+platformId, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -2593,13 +2592,13 @@ func TestListArchsWhenExist(t *testing.T) {
 	router.Use(utils.AuthMiddleware())
 	w := httptest.NewRecorder()
 
-	// Define the route for the upload endpoint.
+	// Define the route for the /arch/list endpoint.
 	handler := handler.NewAppHandler(client, appDB, mongoDatabase, redisClient, true)
 	router.GET("/arch/list", func(c *gin.Context) {
 		handler.ListArchs(c)
 	})
 
-	// Create a POST request for the upload endpoint.
+	// Create a POST request for the /arch/list endpoint.
 	req, err := http.NewRequest("GET", "/arch/list", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -2644,13 +2643,13 @@ func TestDeleteArch(t *testing.T) {
 	router.Use(utils.AuthMiddleware())
 	w := httptest.NewRecorder()
 
-	// Define the route for the upload endpoint.
+	// Define the route for the /arch/delete endpoint.
 	handler := handler.NewAppHandler(client, appDB, mongoDatabase, redisClient, true)
 	router.DELETE("/arch/delete", func(c *gin.Context) {
 		handler.DeleteArch(c)
 	})
 
-	// Create a POST request for the upload endpoint.
+	// Create a DELETE request for the /arch/delete endpoint.
 	req, err := http.NewRequest("DELETE", "/arch/delete?id="+archId, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -2725,7 +2724,7 @@ func TestUpdateApp(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Check for the presence of the "updateChannelResult.Updated" key in the response
+	// Check for the presence of the "updateAppResult.Updated" key in the response
 	updated, exists := response["updateAppResult.Updated"]
 	assert.True(t, exists)
 	assert.True(t, updated.(bool))
@@ -2736,13 +2735,13 @@ func TestListAppsWhenExist(t *testing.T) {
 	router.Use(utils.AuthMiddleware())
 	w := httptest.NewRecorder()
 
-	// Define the route for the upload endpoint.
+	// Define the route for the /app/list endpoint.
 	handler := handler.NewAppHandler(client, appDB, mongoDatabase, redisClient, true)
 	router.GET("/app/list", func(c *gin.Context) {
 		handler.ListApps(c)
 	})
 
-	// Create a POST request for the upload endpoint.
+	// Create a GET request for the /app/list endpoint.
 	req, err := http.NewRequest("GET", "/app/list", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -2787,13 +2786,13 @@ func TestDeleteAppMeta(t *testing.T) {
 	router.Use(utils.AuthMiddleware())
 	w := httptest.NewRecorder()
 
-	// Define the route for the upload endpoint.
+	// Define the route for the /app/delete endpoint.
 	handler := handler.NewAppHandler(client, appDB, mongoDatabase, redisClient, true)
 	router.DELETE("/app/delete", func(c *gin.Context) {
 		handler.DeleteApp(c)
 	})
 
-	// Create a POST request for the upload endpoint.
+	// Create a DELETE request for the /app/delete endpoint.
 	req, err := http.NewRequest("DELETE", "/app/delete?id="+idTestappApp, nil)
 	if err != nil {
 		t.Fatal(err)

--- a/faynoSync_test.go
+++ b/faynoSync_test.go
@@ -661,7 +661,7 @@ func TestUploadDuplicateApp(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 
 	// Check the response body for the desired error message.
-	expectedErrorMessage := `{"error":"app with this name, version, and extension already exists"}`
+	expectedErrorMessage := `{"error":"app with this name, version, platform, architecture and extension already exists"}`
 	assert.Equal(t, expectedErrorMessage, w.Body.String())
 }
 

--- a/faynoSync_test.go
+++ b/faynoSync_test.go
@@ -1428,7 +1428,7 @@ func TestMultipleUpload(t *testing.T) {
 	})
 
 	// Create a file to upload (you can replace this with a test file path).
-	filePaths := []string{"testapp.dmg", "testapp.pkg"}
+	filePaths := []string{"testapp.dmg", "testapp.pkg", "LICENSE"}
 	for _, filePath := range filePaths {
 		file, err := os.Open(filePath)
 		if err != nil {
@@ -1657,7 +1657,6 @@ func TestSearch(t *testing.T) {
 
 	expected := []AppInfo{
 		{
-			// AppID:     idTestappApp,
 			AppName:   "testapp",
 			Version:   "0.0.1.137",
 			Channel:   "nightly",
@@ -1674,6 +1673,11 @@ func TestSearch(t *testing.T) {
 					Arch:     "universalArch",
 					Package:  ".pkg",
 				},
+				{
+					Platform: "universalPlatform",
+					Arch:     "universalArch",
+					Package:  "",
+				},
 			},
 			Changelog: []model.Changelog{
 				{
@@ -1684,7 +1688,6 @@ func TestSearch(t *testing.T) {
 			},
 		},
 		{
-			// AppID:     idTestappApp,
 			AppName:   "testapp",
 			Version:   "0.0.2.137",
 			Channel:   "nightly",
@@ -1701,6 +1704,11 @@ func TestSearch(t *testing.T) {
 					Arch:     "universalArch",
 					Package:  ".pkg",
 				},
+				{
+					Platform: "universalPlatform",
+					Arch:     "universalArch",
+					Package:  "",
+				},
 			},
 			Changelog: []model.Changelog{
 				{
@@ -1711,7 +1719,6 @@ func TestSearch(t *testing.T) {
 			},
 		},
 		{
-			// AppID:     idTestappApp,
 			AppName:   "testapp",
 			Version:   "0.0.3.137",
 			Channel:   "nightly",
@@ -1728,6 +1735,11 @@ func TestSearch(t *testing.T) {
 					Arch:     "universalArch",
 					Package:  ".pkg",
 				},
+				{
+					Platform: "universalPlatform",
+					Arch:     "universalArch",
+					Package:  "",
+				},
 			},
 			Changelog: []model.Changelog{
 				{
@@ -1738,7 +1750,6 @@ func TestSearch(t *testing.T) {
 			},
 		},
 		{
-			// AppID:     idTestappApp,
 			AppName:   "testapp",
 			Version:   "0.0.4.137",
 			Channel:   "stable",
@@ -1755,6 +1766,11 @@ func TestSearch(t *testing.T) {
 					Arch:     "universalArch",
 					Package:  ".pkg",
 				},
+				{
+					Platform: "universalPlatform",
+					Arch:     "universalArch",
+					Package:  "",
+				},
 			},
 			Changelog: []model.Changelog{
 				{
@@ -1765,7 +1781,6 @@ func TestSearch(t *testing.T) {
 			},
 		},
 		{
-			// AppID:     idTestappApp,
 			AppName:   "testapp",
 			Version:   "0.0.5.137",
 			Channel:   "stable",
@@ -1781,6 +1796,11 @@ func TestSearch(t *testing.T) {
 					Platform: "universalPlatform",
 					Arch:     "universalArch",
 					Package:  ".pkg",
+				},
+				{
+					Platform: "universalPlatform",
+					Arch:     "universalArch",
+					Package:  "",
 				},
 			},
 			Changelog: []model.Changelog{
@@ -1806,7 +1826,6 @@ func TestSearch(t *testing.T) {
 	}
 
 	for i, expectedApp := range expected {
-		// assert.Equal(t, expectedApp.AppID, actual.Apps[i].AppID)
 		assert.Equal(t, expectedApp.AppName, actual.Apps[i].AppName)
 		assert.Equal(t, expectedApp.Version, actual.Apps[i].Version)
 		assert.Equal(t, expectedApp.Channel, actual.Apps[i].Channel)
@@ -1861,6 +1880,9 @@ func TestFetchkLatestVersionOfApp(t *testing.T) {
 							"pkg": map[string]interface{}{
 								"url": fmt.Sprintf("%s/%s", s3Endpoint, url.PathEscape("testapp/nightly/universalPlatform/universalArch/testapp-0.0.2.137.pkg")),
 							},
+							"no-extension": map[string]interface{}{
+								"url": fmt.Sprintf("%s/%s", s3Endpoint, url.PathEscape("testapp/nightly/universalPlatform/universalArch/testapp-0.0.2.137")),
+							},
 						},
 					},
 				},
@@ -1882,6 +1904,9 @@ func TestFetchkLatestVersionOfApp(t *testing.T) {
 							},
 							"pkg": map[string]interface{}{
 								"url": fmt.Sprintf("%s/%s", s3Endpoint, url.PathEscape("testapp/stable/universalPlatform/universalArch/testapp-0.0.4.137.pkg")),
+							},
+							"no-extension": map[string]interface{}{
+								"url": fmt.Sprintf("%s/%s", s3Endpoint, url.PathEscape("testapp/stable/universalPlatform/universalArch/testapp-0.0.4.137")),
 							},
 						},
 					},
@@ -1949,12 +1974,12 @@ func TestCheckVersion(t *testing.T) {
 				"critical":         true,
 				"update_url_dmg":   fmt.Sprintf("%s/%s", s3Endpoint, url.PathEscape("testapp/nightly/universalPlatform/universalArch/testapp-0.0.2.137.dmg")),
 				"update_url_pkg":   fmt.Sprintf("%s/%s", s3Endpoint, url.PathEscape("testapp/nightly/universalPlatform/universalArch/testapp-0.0.2.137.pkg")),
+				"update_url":       fmt.Sprintf("%s/%s", s3Endpoint, url.PathEscape("testapp/nightly/universalPlatform/universalArch/testapp-0.0.2.137")),
 			},
 			ExpectedCode: http.StatusOK,
-			// Published:    false,
-			Platform: "universalPlatform",
-			Arch:     "universalArch",
-			TestName: "NightlyUpdateAvailable",
+			Platform:     "universalPlatform",
+			Arch:         "universalArch",
+			TestName:     "NightlyUpdateAvailable",
 		},
 		{
 			AppName:     "testapp",
@@ -1964,12 +1989,12 @@ func TestCheckVersion(t *testing.T) {
 				"update_available": false,
 				"update_url_dmg":   fmt.Sprintf("%s/%s", s3Endpoint, url.PathEscape("testapp/nightly/universalPlatform/universalArch/testapp-0.0.2.137.dmg")),
 				"update_url_pkg":   fmt.Sprintf("%s/%s", s3Endpoint, url.PathEscape("testapp/nightly/universalPlatform/universalArch/testapp-0.0.2.137.pkg")),
+				"update_url":       fmt.Sprintf("%s/%s", s3Endpoint, url.PathEscape("testapp/nightly/universalPlatform/universalArch/testapp-0.0.2.137")),
 			},
 			ExpectedCode: http.StatusOK,
-			// Published:    true,
-			Platform: "universalPlatform",
-			Arch:     "universalArch",
-			TestName: "NightlyUpdateAvailable",
+			Platform:     "universalPlatform",
+			Arch:         "universalArch",
+			TestName:     "NightlyUpdateAvailable",
 		},
 		{
 			AppName:     "testapp",
@@ -1979,10 +2004,9 @@ func TestCheckVersion(t *testing.T) {
 				"error": "requested version 0.0.3.137 is newer than the latest version available",
 			},
 			ExpectedCode: http.StatusInternalServerError,
-			// Published:    false,
-			Platform: "universalPlatform",
-			Arch:     "universalArch",
-			TestName: "NightlyUpdateAvailable",
+			Platform:     "universalPlatform",
+			Arch:         "universalArch",
+			TestName:     "NightlyUpdateAvailable",
 		},
 		{
 			AppName:     "testapp",
@@ -1992,12 +2016,12 @@ func TestCheckVersion(t *testing.T) {
 				"update_available": false,
 				"update_url_dmg":   fmt.Sprintf("%s/%s", s3Endpoint, url.PathEscape("testapp/stable/universalPlatform/universalArch/testapp-0.0.4.137.dmg")),
 				"update_url_pkg":   fmt.Sprintf("%s/%s", s3Endpoint, url.PathEscape("testapp/stable/universalPlatform/universalArch/testapp-0.0.4.137.pkg")),
+				"update_url":       fmt.Sprintf("%s/%s", s3Endpoint, url.PathEscape("testapp/stable/universalPlatform/universalArch/testapp-0.0.4.137")),
 			},
 			ExpectedCode: http.StatusOK,
-			// Published:    true,
-			Platform: "universalPlatform",
-			Arch:     "universalArch",
-			TestName: "StableUpdateAvailable",
+			Platform:     "universalPlatform",
+			Arch:         "universalArch",
+			TestName:     "StableUpdateAvailable",
 		},
 		{
 			AppName:     "testapp",

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/uuid v1.3.0 // indirect
+	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/klauspost/compress v1.16.7 // indirect
@@ -81,6 +82,7 @@ require (
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
 	github.com/sirupsen/logrus v1.9.3
+	github.com/slack-go/slack v0.14.0
 	github.com/spf13/afero v1.9.2 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -524,6 +524,7 @@ github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
+github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gobuffalo/attrs v0.0.0-20190224210810-a9411de4debd/go.mod h1:4duuawTqi2wkkpB4ePgWMaai6/Kc6WEz83bhFwpHzj0=
 github.com/gobuffalo/depgen v0.0.0-20190329151759-d478694a28d3/go.mod h1:3STtPUQYuzV0gBVOY3vy6CfMm/ljR4pABfrTeHNLHUY=
 github.com/gobuffalo/depgen v0.1.0/go.mod h1:+ifsuy7fhi15RWncXQQKjWS9JPkdah5sZvtHc2RXGlg=
@@ -633,6 +634,7 @@ github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-containerregistry v0.5.1/go.mod h1:Ct15B4yir3PLOP5jsy0GNeYVaIZs/MK/Jz5any1wFW0=
@@ -684,6 +686,7 @@ github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
+github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
@@ -1104,6 +1107,8 @@ github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/slack-go/slack v0.14.0 h1:6c0UTfbRnvRssZUsZ2qe0Iu07VAMPjRqOa6oX8ewF4k=
+github.com/slack-go/slack v0.14.0/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQdlMQKOw=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=

--- a/mongod/create.go
+++ b/mongod/create.go
@@ -189,15 +189,30 @@ func (c *appRepository) Upload(ctxQuery map[string]interface{}, appLink, extensi
 			}
 		}
 	}
+
 	switch v := uploadResult.(type) {
 	case *mongo.InsertOneResult:
 		insertedID, ok := v.InsertedID.(primitive.ObjectID)
 		if !ok {
 			return nil, errors.New("error extracting ID from InsertOneResult")
 		}
-		return insertedID.Hex(), nil
+		var appData model.SpecificApp
+		err = collection.FindOne(ctx, bson.D{{Key: "_id", Value: insertedID}}).Decode(&appData)
+		if err != nil {
+			return nil, err
+		}
+		logrus.Debugf("Uploaded result to mongo: %+v", appData)
+		return appData, nil
+
 	case primitive.ObjectID:
-		return v.Hex(), nil
+		var appData model.SpecificApp
+		err = collection.FindOne(ctx, bson.D{{Key: "_id", Value: v}}).Decode(&appData)
+		if err != nil {
+			return nil, err
+		}
+		logrus.Debugf("Updated result in mongo: %+v", appData)
+		return appData, nil
+
 	default:
 		return nil, errors.New("unexpected return type")
 	}

--- a/mongod/create.go
+++ b/mongod/create.go
@@ -113,8 +113,8 @@ func (c *appRepository) Upload(ctxQuery map[string]interface{}, appLink, extensi
 		}
 
 		for _, artifact := range appData.Artifacts {
-			if artifact.Package == extension && artifact.Arch == archMeta.ID {
-				msg := "app with this name, version, and extension already exists"
+			if artifact.Package == extension && artifact.Arch == archMeta.ID && artifact.Platform == platformMeta.ID {
+				msg := "app with this name, version, platform, architecture and extension already exists"
 				return msg, errors.New(msg)
 			}
 		}

--- a/mongod/createUser.go
+++ b/mongod/createUser.go
@@ -23,7 +23,6 @@ func CreateUser(client *mongo.Client, dbName *mongo.Database, credentials *model
 		{Key: "password", Value: string(hashedPassword)},
 		{Key: "updated_at", Value: time.Now()},
 	}
-	// user := bson.D{Key: "username", Value: credentials.Username, Key: "password", Value: string(hashedPassword), Key: "updated_at", Value: time.Now()}
 
 	_, err = collection.InsertOne(context.Background(), filter)
 	if err != nil {

--- a/mongod/structs.go
+++ b/mongod/structs.go
@@ -20,6 +20,7 @@ type AppRepository interface {
 	UpdateSpecificApp(objID primitive.ObjectID, ctxQuery map[string]interface{}, appLink, extension string, ctx context.Context) (bool, error)
 	CheckLatestVersion(appName, version, channel, platform, arch string, ctx context.Context) (CheckResult, error)
 	FetchLatestVersionOfApp(appName, channel string, ctx context.Context) ([]*model.SpecificAppWithoutIDs, error)
+	FetchAppByID(appID primitive.ObjectID, ctx context.Context) ([]*model.SpecificAppWithoutIDs, error)
 	CreateChannel(channelName string, ctx context.Context) (interface{}, error)
 	ListChannels(ctx context.Context) ([]*model.Channel, error)
 	CreatePlatform(platformName string, ctx context.Context) (interface{}, error)

--- a/mongod/structs.go
+++ b/mongod/structs.go
@@ -50,6 +50,20 @@ func NewAppRepository(config *connstring.ConnString, client *mongo.Client) AppRe
 	return &appRepository{config: config, client: client}
 }
 
+type Artifact struct {
+	Link    string
+	Package string
+}
+type Changelog struct {
+	Changes string
+}
+type CheckResult struct {
+	Found     bool
+	Critical  bool
+	Artifacts []Artifact
+	Changelog []Changelog
+}
+
 func (c *appRepository) getBasePipeline() mongo.Pipeline {
 	return mongo.Pipeline{
 		bson.D{{Key: "$lookup", Value: bson.M{
@@ -129,18 +143,4 @@ func (c *appRepository) getBasePipeline() mongo.Pipeline {
 		}}},
 		bson.D{{Key: "$limit", Value: 100}},
 	}
-}
-
-type Artifact struct {
-	Link    string
-	Package string
-}
-type Changelog struct {
-	Changes string
-}
-type CheckResult struct {
-	Found     bool
-	Critical  bool
-	Artifacts []Artifact
-	Changelog []Changelog
 }

--- a/server/handler/create/create.go
+++ b/server/handler/create/create.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	db "faynoSync/mongod"
+	"faynoSync/server/utils"
 	"net/http"
 	"time"
 
@@ -35,7 +36,10 @@ func CreateItem(c *gin.Context, repository db.AppRepository, itemType string) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": paramName + " is required"})
 		return
 	}
-
+	if err := utils.ValidateItemName(itemType, paramValue); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
 	var result interface{}
 	var err error
 

--- a/server/handler/handler.go
+++ b/server/handler/handler.go
@@ -49,7 +49,6 @@ type appHandler struct {
 	database        *mongo.Database
 	redisClient     *redis.Client
 	performanceMode bool
-	slack           bool
 }
 
 func NewAppHandler(client *mongo.Client, repo db.AppRepository, db *mongo.Database, redisClient *redis.Client, performanceMode bool) AppHandler {
@@ -58,7 +57,7 @@ func NewAppHandler(client *mongo.Client, repo db.AppRepository, db *mongo.Databa
 
 func (ch *appHandler) HealthCheck(c *gin.Context) {
 	// Call the HealthCheck function from the info package
-	info.HealthCheck(c, ch.client)
+	info.HealthCheck(c, ch.client, ch.redisClient, ch.performanceMode)
 }
 
 func (ch *appHandler) FindLatestVersion(c *gin.Context) {

--- a/server/handler/handler.go
+++ b/server/handler/handler.go
@@ -49,6 +49,7 @@ type appHandler struct {
 	database        *mongo.Database
 	redisClient     *redis.Client
 	performanceMode bool
+	slack           bool
 }
 
 func NewAppHandler(client *mongo.Client, repo db.AppRepository, db *mongo.Database, redisClient *redis.Client, performanceMode bool) AppHandler {

--- a/server/handler/info/info.go
+++ b/server/handler/info/info.go
@@ -15,13 +15,15 @@ func HealthCheck(c *gin.Context, mongoClient *mongo.Client, redisClient *redis.C
 	ctx, ctxCancel := context.WithTimeout(c.Request.Context(), 5*time.Second)
 	defer ctxCancel()
 
-	if err := mongoClient.Ping(ctx, nil); err != nil {
-		logrus.Error("MongoDB connection error: ", err)
-		c.JSON(http.StatusFailedDependency, gin.H{"status": "unhealthy", "details": "MongoDB connection failed"})
-		return
+	if mongoClient != nil {
+		if err := mongoClient.Ping(ctx, nil); err != nil {
+			logrus.Error("MongoDB connection error: ", err)
+			c.JSON(http.StatusFailedDependency, gin.H{"status": "unhealthy", "details": "MongoDB connection failed"})
+			return
+		}
 	}
 
-	if performanceMode {
+	if performanceMode && redisClient != nil {
 		if err := redisClient.Ping(ctx).Err(); err != nil {
 			logrus.Error("Redis connection error: ", err)
 			c.JSON(http.StatusFailedDependency, gin.H{"status": "unhealthy", "details": "Redis connection failed"})

--- a/server/handler/info/latest.go
+++ b/server/handler/info/latest.go
@@ -129,6 +129,12 @@ func FindLatestVersion(c *gin.Context, repository db.AppRepository, db *mongo.Da
 }
 
 func FetchLatestVersionOfApp(c *gin.Context, repository db.AppRepository, rdb *redis.Client, performanceMode bool) {
+	if c.Query("app_name") == "" || c.Query("channel") == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Parameters 'app_name' and 'channel' are required",
+		})
+		return
+	}
 	params := map[string]interface{}{
 		"app_name": c.Query("app_name"),
 		"channel":  c.Query("channel"),

--- a/server/handler/info/latest.go
+++ b/server/handler/info/latest.go
@@ -75,8 +75,13 @@ func FindLatestVersion(c *gin.Context, repository db.AppRepository, db *mongo.Da
 			logrus.Infoln(checkResult)
 			response := gin.H{"update_available": false}
 			for _, artifact := range checkResult.Artifacts {
-				if artifact.Package != "" && artifact.Link != "" {
-					key := "update_url_" + strings.TrimPrefix(artifact.Package, ".")
+				var key string
+				if artifact.Package == "" {
+					key = "update_url"
+				} else if artifact.Package != "" && artifact.Link != "" {
+					key = "update_url_" + strings.TrimPrefix(artifact.Package, ".")
+				}
+				if artifact.Link != "" {
 					response[key] = artifact.Link
 				}
 			}
@@ -93,8 +98,13 @@ func FindLatestVersion(c *gin.Context, repository db.AppRepository, db *mongo.Da
 
 	// Add update URLs to the response
 	for _, artifact := range checkResult.Artifacts {
-		if artifact.Package != "" && artifact.Link != "" {
-			key := "update_url_" + strings.TrimPrefix(artifact.Package, ".")
+		var key string
+		if artifact.Package == "" {
+			key = "update_url"
+		} else if artifact.Package != "" && artifact.Link != "" {
+			key = "update_url_" + strings.TrimPrefix(artifact.Package, ".")
+		}
+		if artifact.Link != "" {
 			response[key] = artifact.Link
 		}
 	}
@@ -173,7 +183,11 @@ func FetchLatestVersionOfApp(c *gin.Context, repository db.AppRepository, rdb *r
 			if params["arch"] != "" && params["arch"] != artifact.Arch {
 				continue
 			}
+
 			packageType := strings.TrimPrefix(artifact.Package, ".")
+			if packageType == "" {
+				packageType = "no-extension"
+			}
 
 			if params["package"] != "" && params["package"] != packageType {
 				continue

--- a/server/handler/update/update.go
+++ b/server/handler/update/update.go
@@ -47,7 +47,10 @@ func UpdateItem(c *gin.Context, repository db.AppRepository, itemType string) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": paramName + " is required"})
 		return
 	}
-
+	if err := utils.ValidateItemName(itemType, paramValue); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
 	var result interface{}
 	var err error
 	objectID, err := primitive.ObjectIDFromHex(id)

--- a/server/server.go
+++ b/server/server.go
@@ -37,7 +37,6 @@ func StartServer(config *viper.Viper, flags map[string]interface{}) {
 		}
 		redisClient = redisdb.ConnectToRedis(redisConfig)
 	}
-
 	handler := handler.NewAppHandler(client, db, mongoDatabase, redisClient, config.GetBool("PERFORMANCE_MODE"))
 	os.Setenv("API_KEY", config.GetString("API_KEY"))
 

--- a/server/utils/notifications.go
+++ b/server/utils/notifications.go
@@ -1,0 +1,115 @@
+package utils
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/slack-go/slack"
+	"github.com/spf13/viper"
+)
+
+func SendSlackNotification(appName, channel, version string, platforms, arches, artifacts, changelog, extensions []string, env *viper.Viper, publish, critical bool) {
+	token := env.GetString("SLACK_BOT_TOKEN")
+	channelID := env.GetString("SLACK_CHANNEL")
+	api := slack.New(token)
+
+	logrus.WithFields(logrus.Fields{
+		"App Name":            appName,
+		"Channel":             channel,
+		"Version":             version,
+		"Platforms":           platforms,
+		"Archs":               arches,
+		"Number of Artifacts": len(artifacts),
+		"Changelog Entries":   len(changelog),
+	}).Debug("Preparing Slack message with the following details")
+
+	// Create blocks for Slack message
+	blocks := []slack.Block{
+		slack.NewHeaderBlock(&slack.TextBlockObject{
+			Type:  slack.PlainTextType,
+			Text:  "New version of application is uploaded",
+			Emoji: true,
+		}),
+		slack.NewSectionBlock(nil, []*slack.TextBlockObject{
+			slack.NewTextBlockObject("mrkdwn", fmt.Sprintf(":package: *App name:*\n%s", appName), false, false),
+			slack.NewTextBlockObject("mrkdwn", fmt.Sprintf(":bubbles: *Channel name:*\n%s", channel), false, false),
+			slack.NewTextBlockObject("mrkdwn", fmt.Sprintf(":vs: *Version:*\n%s", version), false, false),
+			slack.NewTextBlockObject("mrkdwn", fmt.Sprintf(":loudspeaker: *Published:*\n%t", publish), false, false),
+			slack.NewTextBlockObject("mrkdwn", fmt.Sprintf(":warning: *Critical:*\n%t", critical), false, false),
+		}, nil),
+		slack.NewDividerBlock(),
+		slack.NewHeaderBlock(&slack.TextBlockObject{
+			Type:  slack.PlainTextType,
+			Text:  ":link: Artifacts:",
+			Emoji: true,
+		}),
+	}
+
+	// Add artifact buttons
+	for i, artifact := range artifacts {
+		// A hack for forming URLs for notifications for MinIO on localhost, since MinIO is currently used only for development and the main S3 is only used from AWS, so there is no point in digging into it. Uncomment this for local development.
+		// Also, if this code is uncommented, Slack notifications will be sent from Go tests.
+		// if !strings.HasPrefix(artifact, "http://") && !strings.HasPrefix(artifact, "https://") {
+		// 	artifact = "http://" + artifact
+		// }
+		logrus.Debugf("Adding artifact #%d: %s", i+1, artifact)
+
+		var extension string
+		if i < len(extensions) && extensions[i] != "" {
+			extension = strings.TrimPrefix(extensions[i], ".")
+		} else {
+			extension = "no-ext"
+		}
+		platform := platforms[i]
+		arch := arches[i]
+		downloadText := fmt.Sprintf("*Download for %s (architecture: %s):*",
+			platform, arch)
+
+		blocks = append(blocks, slack.NewSectionBlock(
+			slack.NewTextBlockObject("mrkdwn", downloadText, false, false),
+			nil,
+			slack.NewAccessory(slack.NewButtonBlockElement(
+				"button-action",
+				"click_me_123",
+				slack.NewTextBlockObject("plain_text", extension, true, false),
+			).WithURL(artifact)),
+		))
+	}
+
+	// Add changelog section if available
+	if len(changelog) > 0 {
+		blocks = append(blocks, slack.NewDividerBlock(), slack.NewHeaderBlock(&slack.TextBlockObject{
+			Type: slack.PlainTextType,
+			Text: ":memo: Changelog:",
+		}))
+
+		changelogText := strings.Join(changelog, "\n- ")
+
+		blocks = append(blocks, slack.NewSectionBlock(
+			slack.NewTextBlockObject("mrkdwn", fmt.Sprintf("```%s```", changelogText), false, false),
+			nil,
+			nil,
+		))
+	}
+
+	// Debug output of blocks before sending (make sense for using only on localhost)
+	// for i, block := range blocks {
+	// 	blockJSON, err := json.MarshalIndent(block, "", "  ")
+	// 	if err != nil {
+	// 		logrus.Errorf("Error marshaling block #%d: %s", i+1, err)
+	// 		continue
+	// 	}
+	// 	logrus.Infof("Block #%d JSON: %s", i+1, string(blockJSON))
+	// }
+
+	_, timestamp, err := api.PostMessage(
+		channelID,
+		slack.MsgOptionBlocks(blocks...),
+	)
+	if err != nil {
+		logrus.Errorf("Error sending Slack message: %s", err)
+		return
+	}
+	logrus.Debugf("Message successfully sent to channel %s at %s", channelID, timestamp)
+}

--- a/server/utils/utils.go
+++ b/server/utils/utils.go
@@ -244,8 +244,8 @@ func IsValidVersion(input string) bool {
 }
 
 func IsValidChannelName(input string) bool {
-	// Allow empty input or only letters and numbers, no spaces or special characters
-	validName := regexp.MustCompile(`^[a-zA-Z0-9]*$`)
+	// Allow empty input or only letters, numbers, and hyphens, no spaces or other special characters
+	validName := regexp.MustCompile(`^[a-zA-Z0-9-]*$`)
 	return validName.MatchString(input)
 }
 

--- a/server/utils/utils.go
+++ b/server/utils/utils.go
@@ -232,6 +232,30 @@ func validateCommonParams(ctxQueryMap map[string]interface{}, database *mongo.Da
 	return ctxQueryMap, nil
 }
 
+func ValidateItemName(itemType, paramValue string) error {
+	switch itemType {
+	case "channel":
+		if !IsValidChannelName(paramValue) {
+			return errors.New("invalid channel name")
+		}
+	case "platform":
+		if !IsValidPlatformName(paramValue) {
+			return errors.New("invalid platform name")
+		}
+	case "arch":
+		if !IsValidArchName(paramValue) {
+			return errors.New("invalid architecture name")
+		}
+	case "app":
+		if !IsValidAppName(paramValue) {
+			return errors.New("invalid app name")
+		}
+	default:
+		return errors.New("invalid item type")
+	}
+	return nil
+}
+
 func IsValidAppName(input string) bool {
 	// Only allow letters and numbers, no special characters
 	validName := regexp.MustCompile(`^[a-zA-Z0-9\- ]+$`)

--- a/server/utils/utils.go
+++ b/server/utils/utils.go
@@ -110,7 +110,7 @@ func ValidateParamsLatest(c *gin.Context, database *mongo.Database) (map[string]
 	}
 
 	if !IsValidArchName(ctxQueryMap["arch"].(string)) {
-		return nil, errors.New("invalid platform parameter")
+		return nil, errors.New("invalid arch parameter")
 	}
 
 	errChannels := CheckChannels(ctxQueryMap["channel"].(string), database, c)
@@ -244,14 +244,14 @@ func IsValidVersion(input string) bool {
 }
 
 func IsValidChannelName(input string) bool {
-	// Allow empty input or only letters, numbers, and hyphens, no spaces or other special characters
-	validName := regexp.MustCompile(`^[a-zA-Z0-9-]*$`)
+	// Allow empty input or only letters and numbers, no spaces or special characters
+	validName := regexp.MustCompile(`^[a-zA-Z0-9]*$`)
 	return validName.MatchString(input)
 }
 
 func IsValidPlatformName(input string) bool {
-	// Allow empty input or only letters and numbers, no spaces or special characters
-	validName := regexp.MustCompile(`^[a-zA-Z0-9]*$`)
+	// Allow empty input or only letters, numbers, and hyphens, no spaces or other special characters
+	validName := regexp.MustCompile(`^[a-zA-Z0-9-]*$`)
 	return validName.MatchString(input)
 }
 

--- a/server/utils/utils.go
+++ b/server/utils/utils.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"faynoSync/server/model"
 	"net/http"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -14,7 +13,6 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
-	"go.mongodb.org/mongo-driver/mongo"
 )
 
 type Configuration struct {
@@ -31,25 +29,6 @@ type ServerSettings struct {
 	Port string
 }
 
-func CountUrls(downloadUrls map[string]map[string]map[string]map[string]map[string]string) (int, string) {
-	count := 0
-	var singleUrl string
-	for _, platformMap := range downloadUrls {
-		for _, archMap := range platformMap {
-			for _, packageMap := range archMap {
-				for _, urlMap := range packageMap {
-					if url, exists := urlMap["url"]; exists {
-						count++
-						singleUrl = url
-					}
-				}
-			}
-		}
-	}
-
-	return count, singleUrl
-}
-
 // GenerateJWT generates a new JWT token for the given username
 func GenerateJWT(username string) (string, error) {
 	env := viper.GetViper()
@@ -63,102 +42,6 @@ func GenerateJWT(username string) (string, error) {
 	return token.SignedString([]byte(env.GetString("JWT_SECRET")))
 }
 
-// ValidateJWT parses and validates the JWT token
-func ValidateJWT(tokenString string) (*jwt.Token, error) {
-	env := viper.GetViper()
-	// Parse the token with the secret key
-	return jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
-		// Ensure the signing method is HMAC
-		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-			return nil, jwt.ErrInvalidKey
-		}
-		return []byte(env.GetString("JWT_SECRET")), nil
-	})
-}
-
-func GetStringValue(m map[string]interface{}, key string) string {
-	if val, ok := m[key]; ok {
-		if strVal, ok := val.(string); ok {
-			return strVal
-		}
-	}
-	return ""
-}
-
-func ValidateParamsLatest(c *gin.Context, database *mongo.Database) (map[string]interface{}, error) {
-	ctxQueryMap := map[string]interface{}{
-		"app_name": c.Query("app_name"),
-		"version":  c.Query("version"),
-		"channel":  c.Query("channel"),
-		"publish":  c.Query("publish"),
-		"platform": c.Query("platform"),
-		"arch":     c.Query("arch"),
-	}
-
-	if !IsValidAppName(ctxQueryMap["app_name"].(string)) {
-		return nil, errors.New("invalid app_name parameter")
-	}
-	if !IsValidVersion(ctxQueryMap["version"].(string)) {
-		return nil, errors.New("invalid version parameter")
-	}
-	if !IsValidChannelName(ctxQueryMap["channel"].(string)) {
-		return nil, errors.New("invalid channel parameter")
-	}
-
-	if !IsValidPlatformName(ctxQueryMap["platform"].(string)) {
-		return nil, errors.New("invalid platform parameter")
-	}
-
-	if !IsValidArchName(ctxQueryMap["arch"].(string)) {
-		return nil, errors.New("invalid arch parameter")
-	}
-
-	errChannels := CheckChannels(ctxQueryMap["channel"].(string), database, c)
-	if errChannels != nil {
-		return nil, errChannels
-	}
-
-	updatedPlatform, errPlatforms := CheckPlatformsLatest(ctxQueryMap["platform"].(string), database, c)
-	if errPlatforms != nil {
-		return nil, errPlatforms
-	}
-	ctxQueryMap["platform"] = updatedPlatform
-	updatedArch, errArchs := CheckArchsLatest(ctxQueryMap["arch"].(string), database, c)
-	if errArchs != nil {
-		return nil, errArchs
-	}
-	ctxQueryMap["arch"] = updatedArch
-	return ctxQueryMap, nil
-}
-
-func ValidateParams(c *gin.Context, database *mongo.Database) (map[string]interface{}, error) {
-	var ctxQueryMap map[string]interface{}
-	var err error
-
-	if c.Request.Method == http.MethodPost {
-		ctxQueryMap, err = extractParamsFromPost(c)
-	} else if c.Request.Method == http.MethodGet || c.Request.Method == http.MethodDelete {
-		ctxQueryMap, err = extractParamsFromGetOrDelete(c)
-	} else {
-		return nil, errors.New("unsupported request method")
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	return validateCommonParams(ctxQueryMap, database, c)
-}
-func GetBoolParam(param interface{}) bool {
-	switch v := param.(type) {
-	case bool:
-		return v
-	case string:
-		return v == "true"
-	default:
-		return false
-	}
-}
 func extractParamsFromPost(c *gin.Context) (map[string]interface{}, error) {
 	jsonData := c.PostForm("data")
 	if jsonData == "" {
@@ -202,85 +85,41 @@ func extractParamsFromGetOrDelete(c *gin.Context) (map[string]interface{}, error
 	}, nil
 }
 
-func validateCommonParams(ctxQueryMap map[string]interface{}, database *mongo.Database, c *gin.Context) (map[string]interface{}, error) {
-	if !IsValidAppName(ctxQueryMap["app_name"].(string)) {
-		return nil, errors.New("invalid app_name parameter")
+func GetStringValue(m map[string]interface{}, key string) string {
+	if val, ok := m[key]; ok {
+		if strVal, ok := val.(string); ok {
+			return strVal
+		}
 	}
-	if !IsValidVersion(ctxQueryMap["version"].(string)) {
-		return nil, errors.New("invalid version parameter")
-	}
-	if !IsValidChannelName(ctxQueryMap["channel"].(string)) {
-		return nil, errors.New("invalid channel parameter")
-	}
-	if !IsValidPlatformName(ctxQueryMap["platform"].(string)) {
-		return nil, errors.New("invalid platform parameter")
-	}
-	if !IsValidArchName(ctxQueryMap["arch"].(string)) {
-		return nil, errors.New("invalid arch parameter")
-	}
-
-	if err := CheckChannels(ctxQueryMap["channel"].(string), database, c); err != nil {
-		return nil, err
-	}
-	if err := CheckPlatforms(ctxQueryMap["platform"].(string), database, c); err != nil {
-		return nil, err
-	}
-	if err := CheckArchs(ctxQueryMap["arch"].(string), database, c); err != nil {
-		return nil, err
-	}
-
-	return ctxQueryMap, nil
+	return ""
 }
 
-func ValidateItemName(itemType, paramValue string) error {
-	switch itemType {
-	case "channel":
-		if !IsValidChannelName(paramValue) {
-			return errors.New("invalid channel name")
-		}
-	case "platform":
-		if !IsValidPlatformName(paramValue) {
-			return errors.New("invalid platform name")
-		}
-	case "arch":
-		if !IsValidArchName(paramValue) {
-			return errors.New("invalid architecture name")
-		}
-	case "app":
-		if !IsValidAppName(paramValue) {
-			return errors.New("invalid app name")
-		}
+func GetBoolParam(param interface{}) bool {
+	switch v := param.(type) {
+	case bool:
+		return v
+	case string:
+		return v == "true"
 	default:
-		return errors.New("invalid item type")
+		return false
 	}
-	return nil
 }
 
-func IsValidAppName(input string) bool {
-	// Only allow letters and numbers, no special characters
-	validName := regexp.MustCompile(`^[a-zA-Z0-9\- ]+$`)
-	return validName.MatchString(input)
-}
-func IsValidVersion(input string) bool {
-	// Only allow numbers and dots, no spaces or special characters
-	validVersion := regexp.MustCompile(`^[0-9.-]+$`)
-	return validVersion.MatchString(input)
-}
+func CountUrls(downloadUrls map[string]map[string]map[string]map[string]map[string]string) (int, string) {
+	count := 0
+	var singleUrl string
+	for _, platformMap := range downloadUrls {
+		for _, archMap := range platformMap {
+			for _, packageMap := range archMap {
+				for _, urlMap := range packageMap {
+					if url, exists := urlMap["url"]; exists {
+						count++
+						singleUrl = url
+					}
+				}
+			}
+		}
+	}
 
-func IsValidChannelName(input string) bool {
-	// Allow empty input or only letters and numbers, no spaces or special characters
-	validName := regexp.MustCompile(`^[a-zA-Z0-9]*$`)
-	return validName.MatchString(input)
-}
-
-func IsValidPlatformName(input string) bool {
-	// Allow empty input or only letters, numbers, and hyphens, no spaces or other special characters
-	validName := regexp.MustCompile(`^[a-zA-Z0-9-]*$`)
-	return validName.MatchString(input)
-}
-
-func IsValidArchName(input string) bool {
-	// Allow empty input or only letters and numbers, no spaces or special characters
-	validName := regexp.MustCompile(`^[a-zA-Z0-9]*$`)
-	return validName.MatchString(input)
+	return count, singleUrl
 }

--- a/server/utils/utils.go
+++ b/server/utils/utils.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"faynoSync/server/model"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -122,4 +123,34 @@ func CountUrls(downloadUrls map[string]map[string]map[string]map[string]map[stri
 	}
 
 	return count, singleUrl
+}
+
+func ExtractArtifactLinks(results []interface{}) []string {
+	var artifacts []string
+	uniqueArtifacts := make(map[string]struct{})
+
+	for _, result := range results {
+		if appData, ok := result.(model.SpecificApp); ok {
+			for _, artifact := range appData.Artifacts {
+				key := fmt.Sprintf("%s|%s", artifact.Link, artifact.Package)
+				if _, exists := uniqueArtifacts[key]; !exists {
+					uniqueArtifacts[key] = struct{}{}
+					artifacts = append(artifacts, artifact.Link)
+				}
+			}
+		}
+	}
+	return artifacts
+}
+
+func ExtractChangelog(results []interface{}) []string {
+	var changelog []string
+	if appData, ok := results[0].(model.SpecificApp); ok {
+		for _, change := range appData.Changelog {
+			if change.Changes != "" {
+				changelog = append(changelog, change.Changes)
+			}
+		}
+	}
+	return changelog
 }

--- a/server/utils/validate.go
+++ b/server/utils/validate.go
@@ -1,0 +1,173 @@
+package utils
+
+import (
+	"errors"
+	"net/http"
+	"regexp"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/spf13/viper"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// ValidateJWT parses and validates the JWT token
+func ValidateJWT(tokenString string) (*jwt.Token, error) {
+	env := viper.GetViper()
+	// Parse the token with the secret key
+	return jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+		// Ensure the signing method is HMAC
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, jwt.ErrInvalidKey
+		}
+		return []byte(env.GetString("JWT_SECRET")), nil
+	})
+}
+
+func ValidateParamsLatest(c *gin.Context, database *mongo.Database) (map[string]interface{}, error) {
+	ctxQueryMap := map[string]interface{}{
+		"app_name": c.Query("app_name"),
+		"version":  c.Query("version"),
+		"channel":  c.Query("channel"),
+		"publish":  c.Query("publish"),
+		"platform": c.Query("platform"),
+		"arch":     c.Query("arch"),
+	}
+
+	if !IsValidAppName(ctxQueryMap["app_name"].(string)) {
+		return nil, errors.New("invalid app_name parameter")
+	}
+	if !IsValidVersion(ctxQueryMap["version"].(string)) {
+		return nil, errors.New("invalid version parameter")
+	}
+	if !IsValidChannelName(ctxQueryMap["channel"].(string)) {
+		return nil, errors.New("invalid channel parameter")
+	}
+
+	if !IsValidPlatformName(ctxQueryMap["platform"].(string)) {
+		return nil, errors.New("invalid platform parameter")
+	}
+
+	if !IsValidArchName(ctxQueryMap["arch"].(string)) {
+		return nil, errors.New("invalid arch parameter")
+	}
+
+	errChannels := CheckChannels(ctxQueryMap["channel"].(string), database, c)
+	if errChannels != nil {
+		return nil, errChannels
+	}
+
+	updatedPlatform, errPlatforms := CheckPlatformsLatest(ctxQueryMap["platform"].(string), database, c)
+	if errPlatforms != nil {
+		return nil, errPlatforms
+	}
+	ctxQueryMap["platform"] = updatedPlatform
+	updatedArch, errArchs := CheckArchsLatest(ctxQueryMap["arch"].(string), database, c)
+	if errArchs != nil {
+		return nil, errArchs
+	}
+	ctxQueryMap["arch"] = updatedArch
+	return ctxQueryMap, nil
+}
+
+func ValidateParams(c *gin.Context, database *mongo.Database) (map[string]interface{}, error) {
+	var ctxQueryMap map[string]interface{}
+	var err error
+
+	if c.Request.Method == http.MethodPost {
+		ctxQueryMap, err = extractParamsFromPost(c)
+	} else if c.Request.Method == http.MethodGet || c.Request.Method == http.MethodDelete {
+		ctxQueryMap, err = extractParamsFromGetOrDelete(c)
+	} else {
+		return nil, errors.New("unsupported request method")
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return validateCommonParams(ctxQueryMap, database, c)
+}
+
+func validateCommonParams(ctxQueryMap map[string]interface{}, database *mongo.Database, c *gin.Context) (map[string]interface{}, error) {
+	if !IsValidAppName(ctxQueryMap["app_name"].(string)) {
+		return nil, errors.New("invalid app_name parameter")
+	}
+	if !IsValidVersion(ctxQueryMap["version"].(string)) {
+		return nil, errors.New("invalid version parameter")
+	}
+	if !IsValidChannelName(ctxQueryMap["channel"].(string)) {
+		return nil, errors.New("invalid channel parameter")
+	}
+	if !IsValidPlatformName(ctxQueryMap["platform"].(string)) {
+		return nil, errors.New("invalid platform parameter")
+	}
+	if !IsValidArchName(ctxQueryMap["arch"].(string)) {
+		return nil, errors.New("invalid arch parameter")
+	}
+
+	if err := CheckChannels(ctxQueryMap["channel"].(string), database, c); err != nil {
+		return nil, err
+	}
+	if err := CheckPlatforms(ctxQueryMap["platform"].(string), database, c); err != nil {
+		return nil, err
+	}
+	if err := CheckArchs(ctxQueryMap["arch"].(string), database, c); err != nil {
+		return nil, err
+	}
+
+	return ctxQueryMap, nil
+}
+
+func ValidateItemName(itemType, paramValue string) error {
+	switch itemType {
+	case "channel":
+		if !IsValidChannelName(paramValue) {
+			return errors.New("invalid channel name")
+		}
+	case "platform":
+		if !IsValidPlatformName(paramValue) {
+			return errors.New("invalid platform name")
+		}
+	case "arch":
+		if !IsValidArchName(paramValue) {
+			return errors.New("invalid architecture name")
+		}
+	case "app":
+		if !IsValidAppName(paramValue) {
+			return errors.New("invalid app name")
+		}
+	default:
+		return errors.New("invalid item type")
+	}
+	return nil
+}
+
+func IsValidAppName(input string) bool {
+	// Only allow letters and numbers, no special characters
+	validName := regexp.MustCompile(`^[a-zA-Z0-9\- ]+$`)
+	return validName.MatchString(input)
+}
+func IsValidVersion(input string) bool {
+	// Only allow numbers and dots, no spaces or special characters
+	validVersion := regexp.MustCompile(`^[0-9.-]+$`)
+	return validVersion.MatchString(input)
+}
+
+func IsValidChannelName(input string) bool {
+	// Allow empty input or only letters and numbers, no spaces or special characters
+	validName := regexp.MustCompile(`^[a-zA-Z0-9]*$`)
+	return validName.MatchString(input)
+}
+
+func IsValidPlatformName(input string) bool {
+	// Allow empty input or only letters, numbers, and hyphens, no spaces or other special characters
+	validName := regexp.MustCompile(`^[a-zA-Z0-9-]*$`)
+	return validName.MatchString(input)
+}
+
+func IsValidArchName(input string) bool {
+	// Allow empty input or only letters and numbers, no spaces or special characters
+	validName := regexp.MustCompile(`^[a-zA-Z0-9]*$`)
+	return validName.MatchString(input)
+}


### PR DESCRIPTION
## v1.3.7

### Features
- Added `binary` app support.
- Allowed `-` in platform name.
- Added `Slack` notifications.
- Added required parameter validation for `app_name` and `channel` in `FetchLatestVersionOfApp` endpoint. Returns an error if either parameter is missing.
- Added a database connection check to the health check.

### Bug Fixes

- Added validateParams to Update\Create app/channel/platform/arch
- Fixed an issue with `CheckLatestVersion` where cached metadata values persisted across calls, by moving `appMeta`, `channelMeta`, `platformMeta`, and `archMeta` to local variables.