### PR TITLE
(release) v1.5.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## v1.5.11
+
+### Features
+
+- Added `POST /tuf/v1/bootstrap/recovery` to rebuild bootstrap Redis settings from persisted TUF metadata for already initialized repositories.
+- Added asynchronous `bootstrap_recovery` task flow with lock protection, recovery prechecks, timeout support, and task status reporting.
+
+### Security & Access Control
+
+- Added RBAC edit permission checks for TUF task status, artifact publish, and artifact delete endpoints.
+- Added owner resolution middleware for team users so TUF artifact operations run under resolved owner context.
+
+### Reliability
+
+- Unified bootstrap settings persistence and recovery via a shared Redis save path, including delegated role expirations and `ROOT_SIGNING` initialization.
+
+### API Tooling
+
+- Updated Postman collection with bootstrap recovery API request examples.
+
 ## v1.5.10
 
 ### Dependencies

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,8 +17,6 @@
 - ~~**Electron Builder**~~
 - **Sparkle** 
 - ~~**Tauri**~~
-- **[go-update](https://github.com/inconshreveable/go-update)**
-- **[self_update](https://github.com/jaemk/self_update)** 
 - ~~**[go-tuf](https://github.com/theupdateframework/go-tuf)**~~ (Partially implemented - pilot version)
 - **etc...**
 
@@ -28,18 +26,17 @@
 - ✅ **Pilot version implemented** - Core functionality is operational but requires additional work before production deployment
 
 ### Testing & Quality
-- [ ] Add comprehensive unit tests for TUF functionality
+- [x] Add comprehensive unit tests for TUF functionality
 
 ### Delegations Management
-- [ ] **POST /tuf/v1/delegations** - Create new delegation
-- [ ] **PUT /tuf/v1/delegations** - Update existing delegation
-- [ ] **POST /tuf/v1/delegations/delete** - Delete delegation
-- [ ] Evaluate if delegations make sense for faynoSync use case
+- [ ] **POST /tuf/v1/delegations** - Create new delegation (?)
+- [ ] **PUT /tuf/v1/delegations** - Update existing delegation (?)
+- [ ] **POST /tuf/v1/delegations/delete** - Delete delegation (?)
+- [ ] Evaluate if delegations make sense for faynoSync use case (?)
 
 ### Metadata Management Enhancements
 - [x] **POST /tuf/v1/metadata/sign/delete** - Delete metadata in signing process
 - [x] **POST /tuf/v1/metadata/online** - Force new version of online metadata
-- [ ] Evaluate and implement full online signing functionality through MongoDB (partial functionality exists)
 
 ### Documentation & Tooling
 - [x] Update Postman template with TUF endpoints
@@ -48,11 +45,11 @@
 - [ ] Document TUF configuration and setup process
 
 ### Security & Key Management
-- [ ] Add support for key types other than ed25519 (e.g., RSA, ECDSA)
+- [x] Add support for key types other than ed25519 (e.g., RSA, ECDSA)
 
 ### Future Improvements
 - [ ] Performance optimizations for large repositories
-- [ ] Enhanced error handling and recovery mechanisms
+- [x] Enhanced error handling and recovery mechanisms
 - [ ] Metadata versioning and rollback capabilities
 - [ ] Support for additional hash algorithms
-- [ ] Refactor or remove unused endpoints (e.g., `/tuf/v1/bootstrap/locks`, `/tuf/v1/bootstrap/generate`) 
+- [x] Refactor or remove unused endpoints (e.g., `/tuf/v1/bootstrap/locks`, `/tuf/v1/bootstrap/generate`) 

--- a/examples/faynoSync.postman_collection.json
+++ b/examples/faynoSync.postman_collection.json
@@ -1921,6 +1921,45 @@
         }
       },
       "response": []
+    },
+    {
+      "name": "Bootstrap recovery",
+      "request": {
+        "auth": {
+          "type": "bearer",
+          "bearer": [
+            {
+              "key": "token",
+              "value": "{{faynoSyncToken}}",
+              "type": "string"
+            }
+          ]
+        },
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n    \"appName\": \"tuf\",\n    \"timeout\": 2\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "{{URL}}/tuf/v1/bootstrap/recovery",
+          "host": [
+            "{{URL}}"
+          ],
+          "path": [
+            "tuf",
+            "v1",
+            "bootstrap",
+            "recovery"
+          ]
+        }
+      },
+      "response": []
     }
   ],
   "auth": {

--- a/server/tuf/artifacts/handlers.go
+++ b/server/tuf/artifacts/handlers.go
@@ -27,7 +27,7 @@ type PublishArtifactsPayload struct {
 }
 
 func PostPublishArtifacts(c *gin.Context, redisClient *redis.Client, mongoDatabase *mongo.Database) {
-	owner, err := utils.GetUsernameFromContext(c)
+	owner, err := utils.GetOwnerFromContext(c)
 	if err != nil {
 		logrus.Errorf("Failed to get username from context: %v", err)
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
@@ -274,7 +274,7 @@ func updateAllArtifactsTUFStatus(
 }
 
 func PostDeleteArtifacts(c *gin.Context, redisClient *redis.Client, mongoDatabase *mongo.Database) {
-	owner, err := utils.GetUsernameFromContext(c)
+	owner, err := utils.GetOwnerFromContext(c)
 	if err != nil {
 		logrus.Errorf("Failed to get username from context: %v", err)
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})

--- a/server/tuf/bootstrap/bootstrap.go
+++ b/server/tuf/bootstrap/bootstrap.go
@@ -2,7 +2,9 @@ package bootstrap
 
 import (
 	"context"
+	_ "embed"
 	"encoding/json"
+	"errors"
 	tuf_metadata "faynoSync/server/tuf/metadata"
 	"faynoSync/server/tuf/models"
 	tuf_storage "faynoSync/server/tuf/storage"
@@ -30,7 +32,53 @@ var (
 	downloadMetadataForBootstrap    = tuf_storage.DownloadMetadataFromS3
 	getAllDelegatedRolesForRecovery = tuf_storage.GetAllDelegatedRoles
 	recoverSettingsFromStorageFn    = recoverSettingsFromStorage
+
+	errBootstrapInProgress = errors.New("bootstrap in progress")
 )
+
+//go:embed bootstrap_recovery_finalize.lua
+var bootstrapRecoveryFinalizeLua string
+
+var bootstrapRecoveryFinalizeScript = redis.NewScript(bootstrapRecoveryFinalizeLua)
+
+func isTerminalTaskState(state tasks.TaskState) bool {
+	switch state {
+	case tasks.TaskStateSuccess, tasks.TaskStateFailure, tasks.TaskStateRevoked, tasks.TaskStateRejected, tasks.TaskStateIgnored, tasks.TaskStateErrored:
+		return true
+	default:
+		return false
+	}
+}
+
+func isBootstrapTaskActive(ctx context.Context, redisClient *redis.Client, bootstrapValue string) (bool, string, error) {
+	if !strings.HasPrefix(bootstrapValue, "pre-") {
+		return false, "", nil
+	}
+	bootstrapTaskID := strings.TrimPrefix(bootstrapValue, "pre-")
+	preLockExists, err := redisClient.Exists(ctx, bootstrapValue).Result()
+	if err != nil {
+		return false, bootstrapTaskID, fmt.Errorf("failed to check bootstrap pre-lock %s: %w", bootstrapValue, err)
+	}
+	taskState := getTaskStatusFromRedis(redisClient, bootstrapTaskID)
+	if preLockExists > 0 || !isTerminalTaskState(taskState) {
+		return true, bootstrapTaskID, nil
+	}
+	return false, bootstrapTaskID, nil
+}
+
+func finalizeRecoveredBootstrapMarker(
+	ctx context.Context,
+	redisClient *redis.Client,
+	bootstrapKey string,
+	expectedBootstrapMarker string,
+	recoveryTaskID string,
+) (bool, error) {
+	result, err := bootstrapRecoveryFinalizeScript.Run(ctx, redisClient, []string{bootstrapKey}, expectedBootstrapMarker, recoveryTaskID).Int()
+	if err != nil {
+		return false, err
+	}
+	return result == 1, nil
+}
 
 func scanKeys(ctx context.Context, redisClient *redis.Client, pattern string) ([]string, error) {
 	if redisClient == nil {
@@ -742,11 +790,26 @@ func releaseBootstrapLock(
 	}
 
 	bootstrapKey := "BOOTSTRAP_" + adminName + "_" + appName
-	err = redisClient.Del(ctx, bootstrapKey).Err()
-	if err != nil {
-		logrus.Warnf("Failed to delete BOOTSTRAP key %s: %v", bootstrapKey, err)
+	bootstrapValue, getErr := redisClient.Get(ctx, bootstrapKey).Result()
+	if getErr == redis.Nil {
+		logrus.Debugf("BOOTSTRAP key %s already absent", bootstrapKey)
+	} else if getErr != nil {
+		logrus.Warnf("Failed to read BOOTSTRAP key %s during cleanup: %v", bootstrapKey, getErr)
 	} else {
-		logrus.Debugf("Successfully deleted BOOTSTRAP key: %s", bootstrapKey)
+		expectedPre := "pre-" + taskID
+		if bootstrapValue != expectedPre && bootstrapValue != taskID {
+			logrus.Warnf(
+				"Skipping BOOTSTRAP key cleanup for admin=%s app=%s task_id=%s because current marker belongs to another task: %s",
+				adminName,
+				appName,
+				taskID,
+				bootstrapValue,
+			)
+		} else if err = redisClient.Del(ctx, bootstrapKey).Err(); err != nil {
+			logrus.Warnf("Failed to delete BOOTSTRAP key %s: %v", bootstrapKey, err)
+		} else {
+			logrus.Debugf("Successfully deleted BOOTSTRAP key: %s", bootstrapKey)
+		}
 	}
 
 	logrus.Debugf("Bootstrap lock cleanup completed for admin: %s, app: %s, task_id: %s", adminName, appName, taskID)
@@ -862,9 +925,15 @@ func PostBootstrapRecovery(c *gin.Context, redisClient *redis.Client) {
 		return
 	}
 
-	required, reason, err := isRecoveryRequired(context.Background(), redisClient, adminName, payload.AppName)
+	required, reason, expectedBootstrapMarker, err := isRecoveryRequired(context.Background(), redisClient, adminName, payload.AppName)
 	if err != nil {
 		releaseRecoveryLock(context.Background(), redisClient, lockKey, taskID)
+		if errors.Is(err, errBootstrapInProgress) {
+			c.JSON(http.StatusConflict, gin.H{
+				"error": reason,
+			})
+			return
+		}
 		logrus.Errorf("Failed to evaluate recovery precheck: admin=%s app=%s err=%v", adminName, payload.AppName, err)
 		c.JSON(http.StatusServiceUnavailable, gin.H{
 			"error": "Failed to evaluate recovery precheck",
@@ -886,7 +955,7 @@ func PostBootstrapRecovery(c *gin.Context, redisClient *redis.Client) {
 	go func() {
 		recoveryCtx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
-		runBootstrapRecovery(recoveryCtx, redisClient, taskID, adminName, payload.AppName, lockKey, lockTTL)
+		runBootstrapRecovery(recoveryCtx, redisClient, taskID, adminName, payload.AppName, lockKey, lockTTL, expectedBootstrapMarker)
 	}()
 
 	c.JSON(http.StatusAccepted, gin.H{
@@ -898,7 +967,16 @@ func PostBootstrapRecovery(c *gin.Context, redisClient *redis.Client) {
 	})
 }
 
-func runBootstrapRecovery(ctx context.Context, redisClient *redis.Client, taskID, adminName, appName, lockKey string, lockTTL time.Duration) {
+func runBootstrapRecovery(
+	ctx context.Context,
+	redisClient *redis.Client,
+	taskID,
+	adminName,
+	appName,
+	lockKey string,
+	lockTTL time.Duration,
+	expectedBootstrapMarker string,
+) {
 	logrus.Infof("Starting bootstrap recovery: admin=%s app=%s task_id=%s", adminName, appName, taskID)
 	defer releaseRecoveryLock(ctx, redisClient, lockKey, taskID)
 	if err := redisClient.Expire(ctx, lockKey, lockTTL).Err(); err != nil {
@@ -934,11 +1012,38 @@ func runBootstrapRecovery(ctx context.Context, redisClient *redis.Client, taskID
 	}
 
 	bootstrapKey := "BOOTSTRAP_" + adminName + "_" + appName
-	if err := redisClient.Set(ctx, bootstrapKey, taskID, 0).Err(); err != nil {
+	updated, err := finalizeRecoveredBootstrapMarker(ctx, redisClient, bootstrapKey, expectedBootstrapMarker, taskID)
+	if err != nil {
 		logrus.Errorf("Bootstrap recovery failed while setting BOOTSTRAP key: admin=%s app=%s task_id=%s key=%s err=%v", adminName, appName, taskID, bootstrapKey, err)
 		taskName := tasks.TaskNameBootstrapRecovery
 		success := false
 		errMsg := fmt.Sprintf("Bootstrap recovery failed to set BOOTSTRAP key: %v", err)
+		_ = tasks.SaveTaskStatus(redisClient, taskID, tasks.TaskStateFailure, &tasks.TaskResult{
+			Task:   &taskName,
+			Status: &success,
+			Error:  &errMsg,
+		})
+		return
+	}
+	if !updated {
+		currentBootstrapMarker, readErr := redisClient.Get(ctx, bootstrapKey).Result()
+		if readErr == redis.Nil {
+			currentBootstrapMarker = "<missing>"
+		} else if readErr != nil {
+			currentBootstrapMarker = "<unreadable>"
+		}
+		logrus.Warnf(
+			"Bootstrap recovery aborted due to BOOTSTRAP marker mismatch: admin=%s app=%s task_id=%s key=%s expected=%s current=%s",
+			adminName,
+			appName,
+			taskID,
+			bootstrapKey,
+			expectedBootstrapMarker,
+			currentBootstrapMarker,
+		)
+		taskName := tasks.TaskNameBootstrapRecovery
+		success := false
+		errMsg := fmt.Sprintf("Bootstrap recovery aborted: bootstrap marker changed (expected=%s current=%s)", expectedBootstrapMarker, currentBootstrapMarker)
 		_ = tasks.SaveTaskStatus(redisClient, taskID, tasks.TaskStateFailure, &tasks.TaskResult{
 			Task:   &taskName,
 			Status: &success,
@@ -991,19 +1096,37 @@ func releaseRecoveryLock(ctx context.Context, redisClient *redis.Client, lockKey
 	}
 }
 
-func isRecoveryRequired(ctx context.Context, redisClient *redis.Client, adminName, appName string) (bool, string, error) {
+func isRecoveryRequired(ctx context.Context, redisClient *redis.Client, adminName, appName string) (bool, string, string, error) {
 	if redisClient == nil {
-		return true, "", fmt.Errorf("redis client is nil")
+		return true, "", "", fmt.Errorf("redis client is nil")
 	}
 
 	delegatedRoles, err := getAllDelegatedRolesForRecovery(ctx, adminName, appName)
 	if err != nil {
-		return false, "", err
+		return false, "", "", err
 	}
 
 	keySuffix := adminName + "_" + appName
+	expectedBootstrapMarker := ""
+	bootstrapKey := "BOOTSTRAP_" + keySuffix
+	bootstrapValue, bootstrapErr := redisClient.Get(ctx, bootstrapKey).Result()
+	if bootstrapErr != nil && bootstrapErr != redis.Nil {
+		return false, "", "", fmt.Errorf("failed to read key %s: %w", bootstrapKey, bootstrapErr)
+	}
+	if bootstrapErr == nil && strings.HasPrefix(bootstrapValue, "pre-") {
+		expectedBootstrapMarker = bootstrapValue
+		active, bootstrapTaskID, err := isBootstrapTaskActive(ctx, redisClient, bootstrapValue)
+		if err != nil {
+			return false, "", "", err
+		}
+		if active {
+			reason := fmt.Sprintf("Bootstrap already in progress for this admin and app (task_id=%s)", bootstrapTaskID)
+			return false, reason, expectedBootstrapMarker, errBootstrapInProgress
+		}
+	}
+
 	requiredKeys := []string{
-		"BOOTSTRAP_" + keySuffix,
+		bootstrapKey,
 		"ROOT_EXPIRATION_" + keySuffix,
 		"ROOT_THRESHOLD_" + keySuffix,
 		"ROOT_NUM_KEYS_" + keySuffix,
@@ -1026,30 +1149,26 @@ func isRecoveryRequired(ctx context.Context, redisClient *redis.Client, adminNam
 	for _, key := range requiredKeys {
 		val, err := redisClient.Get(ctx, key).Result()
 		if err == redis.Nil {
-			return true, "", nil
+			return true, "", expectedBootstrapMarker, nil
 		}
 		if err != nil {
-			return false, "", fmt.Errorf("failed to read key %s: %w", key, err)
+			return false, "", "", fmt.Errorf("failed to read key %s: %w", key, err)
 		}
 		if key != "ROOT_SIGNING_"+keySuffix && strings.TrimSpace(val) == "" {
-			return true, "", nil
+			return true, "", expectedBootstrapMarker, nil
 		}
 	}
 
-	bootstrapValue, _ := redisClient.Get(ctx, "BOOTSTRAP_"+keySuffix).Result()
-	if strings.HasPrefix(bootstrapValue, "pre-") {
-		return true, "", nil
-	}
 	rootSigningValue, _ := redisClient.Get(ctx, "ROOT_SIGNING_"+keySuffix).Result()
 	if strings.TrimSpace(rootSigningValue) != "" {
-		return true, "", nil
+		return true, "", expectedBootstrapMarker, nil
 	}
 	targetsOnlineValue, _ := redisClient.Get(ctx, "TARGETS_ONLINE_KEY_"+keySuffix).Result()
 	if targetsOnlineValue != "1" && strings.ToLower(targetsOnlineValue) != "true" {
-		return true, "", nil
+		return true, "", expectedBootstrapMarker, nil
 	}
 
-	return false, "Recovery not required: Redis state is already complete and consistent", nil
+	return false, "Recovery not required: Redis state is already complete and consistent", expectedBootstrapMarker, nil
 }
 
 func recoverSettingsFromStorage(ctx context.Context, adminName, appName string) (recoveredBootstrapSettings, error) {

--- a/server/tuf/bootstrap/bootstrap.go
+++ b/server/tuf/bootstrap/bootstrap.go
@@ -978,7 +978,11 @@ func runBootstrapRecovery(
 	expectedBootstrapMarker string,
 ) {
 	logrus.Infof("Starting bootstrap recovery: admin=%s app=%s task_id=%s", adminName, appName, taskID)
-	defer releaseRecoveryLock(ctx, redisClient, lockKey, taskID)
+	defer func() {
+		releaseCtx, cancel := context.WithTimeout(context.Background(), recoveryLockReleaseTimeout)
+		releaseRecoveryLock(releaseCtx, redisClient, lockKey, taskID)
+		cancel()
+	}()
 	if err := redisClient.Expire(ctx, lockKey, lockTTL).Err(); err != nil {
 		logrus.Warnf("Failed to extend bootstrap recovery lock TTL: admin=%s app=%s task_id=%s ttl=%s err=%v", adminName, appName, taskID, lockTTL, err)
 	}
@@ -1391,9 +1395,10 @@ func expirationDaysFromTime(expiresAt, now time.Time) (int, error) {
 }
 
 const (
-	bootstrapRecoveryLockTTL = 5 * time.Minute
-	maxBootstrapTimeout      = 5 * time.Minute
-	lockBuffer               = 30 * time.Second
+	bootstrapRecoveryLockTTL   = 5 * time.Minute
+	maxBootstrapTimeout        = 5 * time.Minute
+	recoveryLockReleaseTimeout = 5 * time.Second
+	lockBuffer                 = 30 * time.Second
 )
 
 func resolveBootstrapRecoveryTimeoutSeconds(payloadTimeout *int, adminName, appName string) int {

--- a/server/tuf/bootstrap/bootstrap.go
+++ b/server/tuf/bootstrap/bootstrap.go
@@ -80,6 +80,45 @@ func finalizeRecoveredBootstrapMarker(
 	return result == 1, nil
 }
 
+func rollbackRecoveredBootstrapMarker(
+	ctx context.Context,
+	redisClient *redis.Client,
+	bootstrapKey string,
+	recoveryMarker string,
+	restoreValue string,
+) error {
+	const maxRetries = 3
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		err := redisClient.Watch(ctx, func(tx *redis.Tx) error {
+			current, err := tx.Get(ctx, bootstrapKey).Result()
+			if err == redis.Nil {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			if current != recoveryMarker {
+				return nil
+			}
+
+			_, err = tx.TxPipelined(ctx, func(pipe redis.Pipeliner) error {
+				if restoreValue == "" {
+					pipe.Del(ctx, bootstrapKey)
+				} else {
+					pipe.Set(ctx, bootstrapKey, restoreValue, 0)
+				}
+				return nil
+			})
+			return err
+		}, bootstrapKey)
+		if err == redis.TxFailedErr {
+			continue
+		}
+		return err
+	}
+	return fmt.Errorf("failed to rollback BOOTSTRAP marker %s after %d retries", bootstrapKey, maxRetries)
+}
+
 func scanKeys(ctx context.Context, redisClient *redis.Client, pattern string) ([]string, error) {
 	if redisClient == nil {
 		return nil, fmt.Errorf("redis client is nil")
@@ -995,6 +1034,8 @@ func runBootstrapRecovery(
 	}
 	_ = tasks.UpdateTaskState(redisClient, taskID, tasks.TaskStateStarted)
 	_ = tasks.UpdateTaskState(redisClient, taskID, tasks.TaskStateRunning)
+	bootstrapKey := "BOOTSTRAP_" + adminName + "_" + appName
+	recoveryMarker := "RECOVERING_" + taskID
 	recovered, err := recoverSettingsFromStorageFn(ctx, adminName, appName)
 	if err != nil {
 		logrus.Errorf("Bootstrap recovery failed during metadata reconstruction: admin=%s app=%s task_id=%s err=%v", adminName, appName, taskID, err)
@@ -1009,8 +1050,51 @@ func runBootstrapRecovery(
 		return
 	}
 
+	claimed, err := finalizeRecoveredBootstrapMarker(ctx, redisClient, bootstrapKey, expectedBootstrapMarker, recoveryMarker)
+	if err != nil {
+		logrus.Errorf("Bootstrap recovery failed while claiming BOOTSTRAP key: admin=%s app=%s task_id=%s key=%s err=%v", adminName, appName, taskID, bootstrapKey, err)
+		taskName := tasks.TaskNameBootstrapRecovery
+		success := false
+		errMsg := fmt.Sprintf("Bootstrap recovery failed to claim BOOTSTRAP key: %v", err)
+		_ = tasks.SaveTaskStatus(redisClient, taskID, tasks.TaskStateFailure, &tasks.TaskResult{
+			Task:   &taskName,
+			Status: &success,
+			Error:  &errMsg,
+		})
+		return
+	}
+	if !claimed {
+		currentBootstrapMarker, readErr := redisClient.Get(ctx, bootstrapKey).Result()
+		if readErr == redis.Nil {
+			currentBootstrapMarker = "<missing>"
+		} else if readErr != nil {
+			currentBootstrapMarker = "<unreadable>"
+		}
+		logrus.Warnf(
+			"Bootstrap recovery aborted due to BOOTSTRAP marker mismatch while claiming: admin=%s app=%s task_id=%s key=%s expected=%s current=%s",
+			adminName,
+			appName,
+			taskID,
+			bootstrapKey,
+			expectedBootstrapMarker,
+			currentBootstrapMarker,
+		)
+		taskName := tasks.TaskNameBootstrapRecovery
+		success := false
+		errMsg := fmt.Sprintf("Bootstrap recovery aborted: bootstrap marker changed before claiming (expected=%s current=%s)", expectedBootstrapMarker, currentBootstrapMarker)
+		_ = tasks.SaveTaskStatus(redisClient, taskID, tasks.TaskStateFailure, &tasks.TaskResult{
+			Task:   &taskName,
+			Status: &success,
+			Error:  &errMsg,
+		})
+		return
+	}
+
 	if err := saveRecoveredSettings(redisClient, adminName, appName, recovered); err != nil {
 		logrus.Errorf("Bootstrap recovery failed during Redis write: admin=%s app=%s task_id=%s err=%v", adminName, appName, taskID, err)
+		if rollbackErr := rollbackRecoveredBootstrapMarker(ctx, redisClient, bootstrapKey, recoveryMarker, expectedBootstrapMarker); rollbackErr != nil {
+			logrus.Warnf("Failed to rollback in-progress BOOTSTRAP marker after Redis write failure: admin=%s app=%s task_id=%s key=%s err=%v", adminName, appName, taskID, bootstrapKey, rollbackErr)
+		}
 		taskName := tasks.TaskNameBootstrapRecovery
 		success := false
 		errMsg := fmt.Sprintf("Bootstrap recovery failed to save Redis keys: %v", err)
@@ -1022,10 +1106,12 @@ func runBootstrapRecovery(
 		return
 	}
 
-	bootstrapKey := "BOOTSTRAP_" + adminName + "_" + appName
-	updated, err := finalizeRecoveredBootstrapMarker(ctx, redisClient, bootstrapKey, expectedBootstrapMarker, taskID)
+	updated, err := finalizeRecoveredBootstrapMarker(ctx, redisClient, bootstrapKey, recoveryMarker, taskID)
 	if err != nil {
 		logrus.Errorf("Bootstrap recovery failed while setting BOOTSTRAP key: admin=%s app=%s task_id=%s key=%s err=%v", adminName, appName, taskID, bootstrapKey, err)
+		if rollbackErr := rollbackRecoveredBootstrapMarker(ctx, redisClient, bootstrapKey, recoveryMarker, expectedBootstrapMarker); rollbackErr != nil {
+			logrus.Warnf("Failed to rollback in-progress BOOTSTRAP marker after finalize error: admin=%s app=%s task_id=%s key=%s err=%v", adminName, appName, taskID, bootstrapKey, rollbackErr)
+		}
 		taskName := tasks.TaskNameBootstrapRecovery
 		success := false
 		errMsg := fmt.Sprintf("Bootstrap recovery failed to set BOOTSTRAP key: %v", err)

--- a/server/tuf/bootstrap/bootstrap.go
+++ b/server/tuf/bootstrap/bootstrap.go
@@ -3,13 +3,16 @@ package bootstrap
 import (
 	"context"
 	"encoding/json"
-	"faynoSync/server/tuf/metadata"
+	tuf_metadata "faynoSync/server/tuf/metadata"
 	"faynoSync/server/tuf/models"
 	tuf_storage "faynoSync/server/tuf/storage"
 	"faynoSync/server/tuf/tasks"
 	"faynoSync/server/utils"
 	"fmt"
+	"math"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -17,9 +20,17 @@ import (
 	"github.com/go-redis/redis/v8"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
+	"github.com/theupdateframework/go-tuf/v2/examples/repository/repository"
+	gotufmetadata "github.com/theupdateframework/go-tuf/v2/metadata"
 )
 
-var listMetadataForBootstrap = tuf_storage.ListMetadataFromS3
+var (
+	listMetadataForBootstrap        = tuf_storage.ListMetadataFromS3
+	findLatestMetadataBootstrap     = tuf_storage.FindLatestMetadataVersion
+	downloadMetadataForBootstrap    = tuf_storage.DownloadMetadataFromS3
+	getAllDelegatedRolesForRecovery = tuf_storage.GetAllDelegatedRoles
+	recoverSettingsFromStorageFn    = recoverSettingsFromStorage
+)
 
 func scanKeys(ctx context.Context, redisClient *redis.Client, pattern string) ([]string, error) {
 	if redisClient == nil {
@@ -655,7 +666,7 @@ func bootstrapFinalizeWithContext(
 	logrus.Debugf("Starting bootstrap finalization for admin: %s, app: %s", adminName, appName)
 
 	logrus.Debug("Calling bootstrap_online_roles")
-	if err := metadata.BootstrapOnlineRolesWithContext(ctx, redisClient, taskID, adminName, appName, payload); err != nil {
+	if err := tuf_metadata.BootstrapOnlineRolesWithContext(ctx, redisClient, taskID, adminName, appName, payload); err != nil {
 		logrus.Errorf("Bootstrap online roles failed: %v", err)
 		return false
 	}
@@ -768,4 +779,497 @@ func getTaskStatusFromRedis(
 	}
 
 	return taskStatus.State
+}
+
+type bootstrapRecoveryPayload struct {
+	AppName string `json:"appName" binding:"required"`
+	Timeout *int   `json:"timeout,omitempty"`
+}
+
+type minimalTargetsMetadata struct {
+	Signed struct {
+		Expires     string `json:"expires"`
+		Delegations struct {
+			Roles []struct {
+				Name string `json:"name"`
+			} `json:"roles"`
+		} `json:"delegations"`
+	} `json:"signed"`
+}
+
+const bootstrapRecoveryLockTTL = 5 * time.Minute
+
+func PostBootstrapRecovery(c *gin.Context, redisClient *redis.Client) {
+	adminName, err := utils.GetUsernameFromContext(c)
+	if err != nil {
+		logrus.Errorf("Failed to get admin name from context: %v", err)
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		return
+	}
+
+	if redisClient == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{
+			"error": "Redis client is not available",
+		})
+		return
+	}
+
+	var payload bootstrapRecoveryPayload
+	if err := c.ShouldBindJSON(&payload); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": fmt.Sprintf("Invalid payload format: %v", err),
+		})
+		return
+	}
+	if payload.AppName == "" {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": "Missing required field: appName",
+		})
+		return
+	}
+
+	timeout := 300
+	if payload.Timeout != nil && *payload.Timeout > 0 {
+		timeout = *payload.Timeout
+		logrus.Debugf("Timeout: %d", timeout)
+	} else if payload.Timeout != nil {
+		logrus.Warnf("Invalid bootstrap recovery timeout %d seconds for admin %s, app %s. Falling back to default %d seconds", *payload.Timeout, adminName, payload.AppName, timeout)
+	}
+
+	isInitialized, err := hasPersistedRootMetadata(context.Background(), adminName, payload.AppName)
+	if err != nil {
+		logrus.Errorf("Failed to determine bootstrap state from persistent metadata for admin %s, app %s: %v", adminName, payload.AppName, err)
+		c.JSON(http.StatusServiceUnavailable, gin.H{
+			"error": "Failed to determine bootstrap state from persistent metadata",
+		})
+		return
+	}
+	if !isInitialized {
+		c.JSON(http.StatusConflict, gin.H{
+			"error": "No persisted root metadata found. Bootstrap must be completed before recovery.",
+		})
+		return
+	}
+
+	taskID := uuid.New().String()
+	lockKey := "RECOVERY_LOCK_" + adminName + "_" + payload.AppName
+	lockAcquired, err := redisClient.SetNX(context.Background(), lockKey, taskID, bootstrapRecoveryLockTTL).Result()
+	if err != nil {
+		logrus.Errorf("Failed to acquire bootstrap recovery lock: admin=%s app=%s err=%v", adminName, payload.AppName, err)
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "Failed to acquire recovery lock",
+		})
+		return
+	}
+	if !lockAcquired {
+		c.JSON(http.StatusConflict, gin.H{
+			"error": "Recovery already in progress for this admin and app",
+		})
+		return
+	}
+
+	required, reason, err := isRecoveryRequired(context.Background(), redisClient, adminName, payload.AppName)
+	if err != nil {
+		releaseRecoveryLock(context.Background(), redisClient, lockKey, taskID)
+		logrus.Errorf("Failed to evaluate recovery precheck: admin=%s app=%s err=%v", adminName, payload.AppName, err)
+		c.JSON(http.StatusServiceUnavailable, gin.H{
+			"error": "Failed to evaluate recovery precheck",
+		})
+		return
+	}
+	if !required {
+		releaseRecoveryLock(context.Background(), redisClient, lockKey, taskID)
+		c.JSON(http.StatusConflict, gin.H{
+			"error": reason,
+		})
+		return
+	}
+
+	taskName := tasks.TaskNameBootstrapRecovery
+	_ = tasks.SaveTaskStatus(redisClient, taskID, tasks.TaskStatePending, &tasks.TaskResult{
+		Task: &taskName,
+	})
+	go func() {
+		recoveryCtx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+		defer cancel()
+		runBootstrapRecovery(recoveryCtx, redisClient, taskID, adminName, payload.AppName, lockKey)
+	}()
+
+	c.JSON(http.StatusAccepted, gin.H{
+		"data": gin.H{
+			"task_id":     taskID,
+			"last_update": time.Now().Format(time.RFC3339),
+		},
+		"message": "Bootstrap recovery accepted and started in background",
+	})
+}
+
+func runBootstrapRecovery(ctx context.Context, redisClient *redis.Client, taskID, adminName, appName, lockKey string) {
+	logrus.Infof("Starting bootstrap recovery: admin=%s app=%s task_id=%s", adminName, appName, taskID)
+	defer releaseRecoveryLock(ctx, redisClient, lockKey, taskID)
+	_ = tasks.UpdateTaskState(redisClient, taskID, tasks.TaskStateStarted)
+	_ = tasks.UpdateTaskState(redisClient, taskID, tasks.TaskStateRunning)
+	recovered, err := recoverSettingsFromStorageFn(ctx, adminName, appName)
+	if err != nil {
+		logrus.Errorf("Bootstrap recovery failed during metadata reconstruction: admin=%s app=%s task_id=%s err=%v", adminName, appName, taskID, err)
+		taskName := tasks.TaskNameBootstrapRecovery
+		success := false
+		errMsg := fmt.Sprintf("Bootstrap recovery failed: %v", err)
+		_ = tasks.SaveTaskStatus(redisClient, taskID, tasks.TaskStateFailure, &tasks.TaskResult{
+			Task:   &taskName,
+			Status: &success,
+			Error:  &errMsg,
+		})
+		return
+	}
+
+	if err := saveRecoveredSettings(redisClient, adminName, appName, recovered); err != nil {
+		logrus.Errorf("Bootstrap recovery failed during Redis write: admin=%s app=%s task_id=%s err=%v", adminName, appName, taskID, err)
+		taskName := tasks.TaskNameBootstrapRecovery
+		success := false
+		errMsg := fmt.Sprintf("Bootstrap recovery failed to save Redis keys: %v", err)
+		_ = tasks.SaveTaskStatus(redisClient, taskID, tasks.TaskStateFailure, &tasks.TaskResult{
+			Task:   &taskName,
+			Status: &success,
+			Error:  &errMsg,
+		})
+		return
+	}
+
+	bootstrapKey := "BOOTSTRAP_" + adminName + "_" + appName
+	if err := redisClient.Set(ctx, bootstrapKey, taskID, 0).Err(); err != nil {
+		logrus.Errorf("Bootstrap recovery failed while setting BOOTSTRAP key: admin=%s app=%s task_id=%s key=%s err=%v", adminName, appName, taskID, bootstrapKey, err)
+		taskName := tasks.TaskNameBootstrapRecovery
+		success := false
+		errMsg := fmt.Sprintf("Bootstrap recovery failed to set BOOTSTRAP key: %v", err)
+		_ = tasks.SaveTaskStatus(redisClient, taskID, tasks.TaskStateFailure, &tasks.TaskResult{
+			Task:   &taskName,
+			Status: &success,
+			Error:  &errMsg,
+		})
+		return
+	}
+
+	taskName := tasks.TaskNameBootstrapRecovery
+	success := true
+	msg := "Bootstrap recovery completed successfully"
+	_ = tasks.SaveTaskStatus(redisClient, taskID, tasks.TaskStateSuccess, &tasks.TaskResult{
+		Task:    &taskName,
+		Status:  &success,
+		Message: &msg,
+	})
+	logrus.Infof(
+		"Bootstrap recovery completed: admin=%s app=%s task_id=%s delegated_roles=%d root_exp=%d targets_exp=%d snapshot_exp=%d timestamp_exp=%d",
+		adminName,
+		appName,
+		taskID,
+		len(recovered.DelegatedExpiration),
+		recovered.RootExpiration,
+		recovered.TargetsExpiration,
+		recovered.SnapshotExpiration,
+		recovered.TimestampExpiration,
+	)
+}
+
+func releaseRecoveryLock(ctx context.Context, redisClient *redis.Client, lockKey, taskID string) {
+	if redisClient == nil {
+		return
+	}
+
+	current, err := redisClient.Get(ctx, lockKey).Result()
+	if err == redis.Nil {
+		return
+	}
+	if err != nil {
+		logrus.Warnf("Failed to read recovery lock %s: %v", lockKey, err)
+		return
+	}
+
+	if current != taskID {
+		return
+	}
+
+	if err := redisClient.Del(ctx, lockKey).Err(); err != nil {
+		logrus.Warnf("Failed to release recovery lock %s: %v", lockKey, err)
+	}
+}
+
+func isRecoveryRequired(ctx context.Context, redisClient *redis.Client, adminName, appName string) (bool, string, error) {
+	if redisClient == nil {
+		return true, "", fmt.Errorf("redis client is nil")
+	}
+
+	delegatedRoles, err := getAllDelegatedRolesForRecovery(ctx, adminName, appName)
+	if err != nil {
+		return false, "", err
+	}
+
+	keySuffix := adminName + "_" + appName
+	requiredKeys := []string{
+		"BOOTSTRAP_" + keySuffix,
+		"ROOT_EXPIRATION_" + keySuffix,
+		"ROOT_THRESHOLD_" + keySuffix,
+		"ROOT_NUM_KEYS_" + keySuffix,
+		"TARGETS_EXPIRATION_" + keySuffix,
+		"TARGETS_THRESHOLD_" + keySuffix,
+		"TARGETS_NUM_KEYS_" + keySuffix,
+		"TARGETS_ONLINE_KEY_" + keySuffix,
+		"SNAPSHOT_EXPIRATION_" + keySuffix,
+		"SNAPSHOT_THRESHOLD_" + keySuffix,
+		"SNAPSHOT_NUM_KEYS_" + keySuffix,
+		"TIMESTAMP_EXPIRATION_" + keySuffix,
+		"TIMESTAMP_THRESHOLD_" + keySuffix,
+		"TIMESTAMP_NUM_KEYS_" + keySuffix,
+		"ROOT_SIGNING_" + keySuffix,
+	}
+	for _, roleName := range delegatedRoles {
+		requiredKeys = append(requiredKeys, roleName+"_EXPIRATION_"+keySuffix)
+	}
+
+	for _, key := range requiredKeys {
+		val, err := redisClient.Get(ctx, key).Result()
+		if err == redis.Nil {
+			return true, "", nil
+		}
+		if err != nil {
+			return false, "", fmt.Errorf("failed to read key %s: %w", key, err)
+		}
+		if key != "ROOT_SIGNING_"+keySuffix && strings.TrimSpace(val) == "" {
+			return true, "", nil
+		}
+	}
+
+	bootstrapValue, _ := redisClient.Get(ctx, "BOOTSTRAP_"+keySuffix).Result()
+	if strings.HasPrefix(bootstrapValue, "pre-") {
+		return true, "", nil
+	}
+	rootSigningValue, _ := redisClient.Get(ctx, "ROOT_SIGNING_"+keySuffix).Result()
+	if strings.TrimSpace(rootSigningValue) != "" {
+		return true, "", nil
+	}
+	targetsOnlineValue, _ := redisClient.Get(ctx, "TARGETS_ONLINE_KEY_"+keySuffix).Result()
+	if targetsOnlineValue != "1" && strings.ToLower(targetsOnlineValue) != "true" {
+		return true, "", nil
+	}
+
+	return false, "Recovery not required: Redis state is already complete and consistent", nil
+}
+
+func recoverSettingsFromStorage(ctx context.Context, adminName, appName string) (recoveredBootstrapSettings, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return recoveredBootstrapSettings{}, fmt.Errorf("failed to get current working directory: %w", err)
+	}
+	tmpDir, err := os.MkdirTemp(cwd, "tmp-recovery-*")
+	if err != nil {
+		return recoveredBootstrapSettings{}, fmt.Errorf("failed to create temporary directory: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	now := time.Now().UTC()
+	repo := repository.New()
+
+	rootPath, rootFilename, err := downloadLatestRoleMetadata(ctx, adminName, appName, "root", tmpDir)
+	if err != nil {
+		return recoveredBootstrapSettings{}, err
+	}
+	targetsPath, targetsFilename, err := downloadLatestRoleMetadata(ctx, adminName, appName, "targets", tmpDir)
+	if err != nil {
+		return recoveredBootstrapSettings{}, err
+	}
+	snapshotPath, _, err := downloadLatestRoleMetadata(ctx, adminName, appName, "snapshot", tmpDir)
+	if err != nil {
+		return recoveredBootstrapSettings{}, err
+	}
+	timestampPath := filepath.Join(tmpDir, "timestamp.json")
+	if err := downloadMetadataForBootstrap(ctx, adminName, appName, "timestamp.json", timestampPath); err != nil {
+		return recoveredBootstrapSettings{}, fmt.Errorf("failed to download timestamp metadata: %w", err)
+	}
+
+	root := gotufmetadata.Root(now.Add(365 * 24 * time.Hour))
+	repo.SetRoot(root)
+	if _, err := repo.Root().FromFile(rootPath); err != nil {
+		return recoveredBootstrapSettings{}, fmt.Errorf("failed to load root metadata: %w", err)
+	}
+	if err := repo.Root().VerifyDelegate("root", repo.Root()); err != nil {
+		return recoveredBootstrapSettings{}, fmt.Errorf("failed to verify root metadata signatures: %w", err)
+	}
+	if !repo.Root().Signed.Expires.After(now) {
+		return recoveredBootstrapSettings{}, fmt.Errorf("root metadata is expired at %s", repo.Root().Signed.Expires.UTC().Format(time.RFC3339))
+	}
+
+	targets := gotufmetadata.Targets(now.Add(365 * 24 * time.Hour))
+	repo.SetTargets("targets", targets)
+	if _, err := repo.Targets("targets").FromFile(targetsPath); err != nil {
+		return recoveredBootstrapSettings{}, fmt.Errorf("failed to load targets metadata: %w", err)
+	}
+	if err := repo.Root().VerifyDelegate("targets", repo.Targets("targets")); err != nil {
+		return recoveredBootstrapSettings{}, fmt.Errorf("failed to verify targets metadata signatures: %w", err)
+	}
+	if !repo.Targets("targets").Signed.Expires.After(now) {
+		return recoveredBootstrapSettings{}, fmt.Errorf("targets metadata is expired at %s", repo.Targets("targets").Signed.Expires.UTC().Format(time.RFC3339))
+	}
+
+	snapshot := gotufmetadata.Snapshot(now.Add(365 * 24 * time.Hour))
+	repo.SetSnapshot(snapshot)
+	if _, err := repo.Snapshot().FromFile(snapshotPath); err != nil {
+		return recoveredBootstrapSettings{}, fmt.Errorf("failed to load snapshot metadata: %w", err)
+	}
+	if err := repo.Root().VerifyDelegate("snapshot", repo.Snapshot()); err != nil {
+		return recoveredBootstrapSettings{}, fmt.Errorf("failed to verify snapshot metadata signatures: %w", err)
+	}
+	if !repo.Snapshot().Signed.Expires.After(now) {
+		return recoveredBootstrapSettings{}, fmt.Errorf("snapshot metadata is expired at %s", repo.Snapshot().Signed.Expires.UTC().Format(time.RFC3339))
+	}
+
+	timestamp := gotufmetadata.Timestamp(now.Add(365 * 24 * time.Hour))
+	repo.SetTimestamp(timestamp)
+	if _, err := repo.Timestamp().FromFile(timestampPath); err != nil {
+		return recoveredBootstrapSettings{}, fmt.Errorf("failed to load timestamp metadata: %w", err)
+	}
+	if err := repo.Root().VerifyDelegate("timestamp", repo.Timestamp()); err != nil {
+		return recoveredBootstrapSettings{}, fmt.Errorf("failed to verify timestamp metadata signatures: %w", err)
+	}
+	if !repo.Timestamp().Signed.Expires.After(now) {
+		return recoveredBootstrapSettings{}, fmt.Errorf("timestamp metadata is expired at %s", repo.Timestamp().Signed.Expires.UTC().Format(time.RFC3339))
+	}
+
+	rootData, err := os.ReadFile(rootPath)
+	if err != nil {
+		return recoveredBootstrapSettings{}, fmt.Errorf("failed to read root metadata file %s: %w", rootFilename, err)
+	}
+	var rootMetadata models.RootMetadata
+	if err := json.Unmarshal(rootData, &rootMetadata); err != nil {
+		return recoveredBootstrapSettings{}, fmt.Errorf("failed to parse root metadata: %w", err)
+	}
+
+	targetsData, err := os.ReadFile(targetsPath)
+	if err != nil {
+		return recoveredBootstrapSettings{}, fmt.Errorf("failed to read targets metadata file %s: %w", targetsFilename, err)
+	}
+	var targetsMetadata minimalTargetsMetadata
+	if err := json.Unmarshal(targetsData, &targetsMetadata); err != nil {
+		return recoveredBootstrapSettings{}, fmt.Errorf("failed to parse targets metadata for delegations: %w", err)
+	}
+
+	rootExpirationDays, err := expirationDaysFromTime(repo.Root().Signed.Expires, now)
+	if err != nil {
+		return recoveredBootstrapSettings{}, err
+	}
+	targetsExpirationDays, err := expirationDaysFromTime(repo.Targets("targets").Signed.Expires, now)
+	if err != nil {
+		return recoveredBootstrapSettings{}, err
+	}
+	snapshotExpirationDays, err := expirationDaysFromTime(repo.Snapshot().Signed.Expires, now)
+	if err != nil {
+		return recoveredBootstrapSettings{}, err
+	}
+	timestampExpirationDays, err := expirationDaysFromTime(repo.Timestamp().Signed.Expires, now)
+	if err != nil {
+		return recoveredBootstrapSettings{}, err
+	}
+
+	roleThreshold := func(role string) int {
+		r, ok := rootMetadata.Signed.Roles[role]
+		if !ok || r.Threshold < 1 {
+			return 1
+		}
+		return r.Threshold
+	}
+	roleNumKeys := func(role string) int {
+		r, ok := rootMetadata.Signed.Roles[role]
+		if !ok || len(r.KeyIDs) < 1 {
+			return 1
+		}
+		return len(r.KeyIDs)
+	}
+
+	delegatedExpiration := map[string]int{}
+	for _, delegated := range targetsMetadata.Signed.Delegations.Roles {
+		roleName := strings.TrimSpace(delegated.Name)
+		if roleName == "" {
+			continue
+		}
+
+		delegatedPath, _, err := downloadLatestRoleMetadata(ctx, adminName, appName, roleName, tmpDir)
+		if err != nil {
+			logrus.Warnf("Skipping delegated role %s during recovery: %v", roleName, err)
+			continue
+		}
+
+		roleTargets := gotufmetadata.Targets(now.Add(365 * 24 * time.Hour))
+		repo.SetTargets(roleName, roleTargets)
+		if _, err := repo.Targets(roleName).FromFile(delegatedPath); err != nil {
+			logrus.Warnf("Skipping delegated role %s due to parse error: %v", roleName, err)
+			continue
+		}
+		if err := repo.Targets("targets").VerifyDelegate(roleName, repo.Targets(roleName)); err != nil {
+			logrus.Warnf("Skipping delegated role %s due to signature verification error: %v", roleName, err)
+			continue
+		}
+		if !repo.Targets(roleName).Signed.Expires.After(now) {
+			logrus.Warnf("Skipping delegated role %s because metadata is expired", roleName)
+			continue
+		}
+
+		days, err := expirationDaysFromTime(repo.Targets(roleName).Signed.Expires, now)
+		if err != nil {
+			logrus.Warnf("Skipping delegated role %s due to expiration conversion error: %v", roleName, err)
+			continue
+		}
+		delegatedExpiration[roleName] = days
+	}
+
+	return recoveredBootstrapSettings{
+		RootExpiration:      rootExpirationDays,
+		RootThreshold:       roleThreshold("root"),
+		RootNumKeys:         roleNumKeys("root"),
+		TargetsExpiration:   targetsExpirationDays,
+		TargetsThreshold:    roleThreshold("targets"),
+		TargetsNumKeys:      roleNumKeys("targets"),
+		SnapshotExpiration:  snapshotExpirationDays,
+		SnapshotThreshold:   roleThreshold("snapshot"),
+		SnapshotNumKeys:     roleNumKeys("snapshot"),
+		TimestampExpiration: timestampExpirationDays,
+		TimestampThreshold:  roleThreshold("timestamp"),
+		TimestampNumKeys:    roleNumKeys("timestamp"),
+		TargetsOnlineKey:    true,
+		DelegatedExpiration: delegatedExpiration,
+	}, nil
+}
+
+func downloadLatestRoleMetadata(ctx context.Context, adminName, appName, roleName, tmpDir string) (string, string, error) {
+	_, filename, err := findLatestMetadataBootstrap(ctx, adminName, appName, roleName)
+	if err != nil {
+		if roleName == "root" {
+			path := filepath.Join(tmpDir, "root.json")
+			if err := downloadMetadataForBootstrap(ctx, adminName, appName, "root.json", path); err == nil {
+				return path, "root.json", nil
+			}
+
+			path = filepath.Join(tmpDir, "1.root.json")
+			if err := downloadMetadataForBootstrap(ctx, adminName, appName, "1.root.json", path); err == nil {
+				return path, "1.root.json", nil
+			}
+		}
+		return "", "", fmt.Errorf("failed to find latest %s metadata version: %w", roleName, err)
+	}
+
+	path := filepath.Join(tmpDir, filename)
+	if err := downloadMetadataForBootstrap(ctx, adminName, appName, filename, path); err != nil {
+		return "", "", fmt.Errorf("failed to download %s metadata %s: %w", roleName, filename, err)
+	}
+	return path, filename, nil
+}
+
+func expirationDaysFromTime(expiresAt, now time.Time) (int, error) {
+	if !expiresAt.After(now) {
+		return 0, fmt.Errorf("metadata is expired at %s", expiresAt.UTC().Format(time.RFC3339))
+	}
+
+	days := int(math.Ceil(expiresAt.Sub(now).Hours() / 24))
+	if days < 1 {
+		days = 1
+	}
+	return days, nil
 }

--- a/server/tuf/bootstrap/bootstrap.go
+++ b/server/tuf/bootstrap/bootstrap.go
@@ -59,8 +59,8 @@ func isBootstrapTaskActive(ctx context.Context, redisClient *redis.Client, boots
 	if err != nil {
 		return false, bootstrapTaskID, fmt.Errorf("failed to check bootstrap pre-lock %s: %w", bootstrapValue, err)
 	}
-	taskState := getTaskStatusFromRedis(redisClient, bootstrapTaskID)
-	if preLockExists > 0 || !isTerminalTaskState(taskState) {
+	taskState, taskExists := getTaskStatusFromRedisWithFound(redisClient, bootstrapTaskID)
+	if preLockExists > 0 || (taskExists && !isTerminalTaskState(taskState)) {
 		return true, bootstrapTaskID, nil
 	}
 	return false, bootstrapTaskID, nil
@@ -819,8 +819,16 @@ func getTaskStatusFromRedis(
 	redisClient *redis.Client,
 	taskID string,
 ) tasks.TaskState {
+	taskState, _ := getTaskStatusFromRedisWithFound(redisClient, taskID)
+	return taskState
+}
+
+func getTaskStatusFromRedisWithFound(
+	redisClient *redis.Client,
+	taskID string,
+) (tasks.TaskState, bool) {
 	if redisClient == nil {
-		return tasks.TaskStatePending
+		return tasks.TaskStatePending, false
 	}
 
 	ctx := context.Background()
@@ -828,20 +836,19 @@ func getTaskStatusFromRedis(
 
 	taskData, err := redisClient.Get(ctx, taskKey).Result()
 	if err == redis.Nil {
-
-		return tasks.TaskStatePending
+		return tasks.TaskStatePending, false
 	} else if err != nil {
 		logrus.Warnf("Failed to get task status from Redis for task_id %s: %v", taskID, err)
-		return tasks.TaskStatePending
+		return tasks.TaskStatePending, false
 	}
 
 	var taskStatus tasks.TaskStatus
 	if err := json.Unmarshal([]byte(taskData), &taskStatus); err != nil {
 		logrus.Warnf("Failed to unmarshal task status for task_id %s: %v", taskID, err)
-		return tasks.TaskStatePending
+		return tasks.TaskStatePending, false
 	}
 
-	return taskStatus.State
+	return taskStatus.State, true
 }
 
 type bootstrapRecoveryPayload struct {

--- a/server/tuf/bootstrap/bootstrap.go
+++ b/server/tuf/bootstrap/bootstrap.go
@@ -1406,29 +1406,28 @@ func recoverSettingsFromStorage(ctx context.Context, adminName, appName string) 
 
 		delegatedPath, _, err := downloadLatestRoleMetadata(ctx, adminName, appName, roleName, tmpDir)
 		if err != nil {
-			logrus.Warnf("Skipping delegated role %s during recovery: %v", roleName, err)
-			continue
+			return recoveredBootstrapSettings{}, fmt.Errorf("failed to download delegated role metadata for %s: %w", roleName, err)
 		}
 
 		roleTargets := gotufmetadata.Targets(now.Add(365 * 24 * time.Hour))
 		repo.SetTargets(roleName, roleTargets)
 		if _, err := repo.Targets(roleName).FromFile(delegatedPath); err != nil {
-			logrus.Warnf("Skipping delegated role %s due to parse error: %v", roleName, err)
-			continue
+			return recoveredBootstrapSettings{}, fmt.Errorf("failed to load delegated role metadata for %s: %w", roleName, err)
 		}
 		if err := repo.Targets("targets").VerifyDelegate(roleName, repo.Targets(roleName)); err != nil {
-			logrus.Warnf("Skipping delegated role %s due to signature verification error: %v", roleName, err)
-			continue
+			return recoveredBootstrapSettings{}, fmt.Errorf("failed to verify delegated role metadata signatures for %s: %w", roleName, err)
 		}
 		if !repo.Targets(roleName).Signed.Expires.After(now) {
-			logrus.Warnf("Skipping delegated role %s because metadata is expired", roleName)
-			continue
+			return recoveredBootstrapSettings{}, fmt.Errorf(
+				"delegated role %s metadata is expired at %s",
+				roleName,
+				repo.Targets(roleName).Signed.Expires.UTC().Format(time.RFC3339),
+			)
 		}
 
 		days, err := expirationDaysFromTime(repo.Targets(roleName).Signed.Expires, now)
 		if err != nil {
-			logrus.Warnf("Skipping delegated role %s due to expiration conversion error: %v", roleName, err)
-			continue
+			return recoveredBootstrapSettings{}, fmt.Errorf("failed to derive delegated role expiration days for %s: %w", roleName, err)
 		}
 		delegatedExpiration[roleName] = days
 	}

--- a/server/tuf/bootstrap/bootstrap.go
+++ b/server/tuf/bootstrap/bootstrap.go
@@ -797,8 +797,6 @@ type minimalTargetsMetadata struct {
 	} `json:"signed"`
 }
 
-const bootstrapRecoveryLockTTL = 5 * time.Minute
-
 func PostBootstrapRecovery(c *gin.Context, redisClient *redis.Client) {
 	adminName, err := utils.GetUsernameFromContext(c)
 	if err != nil {
@@ -828,13 +826,9 @@ func PostBootstrapRecovery(c *gin.Context, redisClient *redis.Client) {
 		return
 	}
 
-	timeout := 300
-	if payload.Timeout != nil && *payload.Timeout > 0 {
-		timeout = *payload.Timeout
-		logrus.Debugf("Timeout: %d", timeout)
-	} else if payload.Timeout != nil {
-		logrus.Warnf("Invalid bootstrap recovery timeout %d seconds for admin %s, app %s. Falling back to default %d seconds", *payload.Timeout, adminName, payload.AppName, timeout)
-	}
+	timeoutSeconds := resolveBootstrapRecoveryTimeoutSeconds(payload.Timeout, adminName, payload.AppName)
+	timeout := time.Duration(timeoutSeconds) * time.Second
+	lockTTL := calculateBootstrapRecoveryLockTTL(timeout)
 
 	isInitialized, err := hasPersistedRootMetadata(context.Background(), adminName, payload.AppName)
 	if err != nil {
@@ -853,7 +847,7 @@ func PostBootstrapRecovery(c *gin.Context, redisClient *redis.Client) {
 
 	taskID := uuid.New().String()
 	lockKey := "RECOVERY_LOCK_" + adminName + "_" + payload.AppName
-	lockAcquired, err := redisClient.SetNX(context.Background(), lockKey, taskID, bootstrapRecoveryLockTTL).Result()
+	lockAcquired, err := redisClient.SetNX(context.Background(), lockKey, taskID, lockTTL).Result()
 	if err != nil {
 		logrus.Errorf("Failed to acquire bootstrap recovery lock: admin=%s app=%s err=%v", adminName, payload.AppName, err)
 		c.JSON(http.StatusInternalServerError, gin.H{
@@ -890,9 +884,9 @@ func PostBootstrapRecovery(c *gin.Context, redisClient *redis.Client) {
 		Task: &taskName,
 	})
 	go func() {
-		recoveryCtx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
+		recoveryCtx, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
-		runBootstrapRecovery(recoveryCtx, redisClient, taskID, adminName, payload.AppName, lockKey)
+		runBootstrapRecovery(recoveryCtx, redisClient, taskID, adminName, payload.AppName, lockKey, lockTTL)
 	}()
 
 	c.JSON(http.StatusAccepted, gin.H{
@@ -904,9 +898,12 @@ func PostBootstrapRecovery(c *gin.Context, redisClient *redis.Client) {
 	})
 }
 
-func runBootstrapRecovery(ctx context.Context, redisClient *redis.Client, taskID, adminName, appName, lockKey string) {
+func runBootstrapRecovery(ctx context.Context, redisClient *redis.Client, taskID, adminName, appName, lockKey string, lockTTL time.Duration) {
 	logrus.Infof("Starting bootstrap recovery: admin=%s app=%s task_id=%s", adminName, appName, taskID)
 	defer releaseRecoveryLock(ctx, redisClient, lockKey, taskID)
+	if err := redisClient.Expire(ctx, lockKey, lockTTL).Err(); err != nil {
+		logrus.Warnf("Failed to extend bootstrap recovery lock TTL: admin=%s app=%s task_id=%s ttl=%s err=%v", adminName, appName, taskID, lockTTL, err)
+	}
 	_ = tasks.UpdateTaskState(redisClient, taskID, tasks.TaskStateStarted)
 	_ = tasks.UpdateTaskState(redisClient, taskID, tasks.TaskStateRunning)
 	recovered, err := recoverSettingsFromStorageFn(ctx, adminName, appName)
@@ -1272,4 +1269,42 @@ func expirationDaysFromTime(expiresAt, now time.Time) (int, error) {
 		days = 1
 	}
 	return days, nil
+}
+
+const (
+	bootstrapRecoveryLockTTL = 5 * time.Minute
+	maxBootstrapTimeout      = 5 * time.Minute
+	lockBuffer               = 30 * time.Second
+)
+
+func resolveBootstrapRecoveryTimeoutSeconds(payloadTimeout *int, adminName, appName string) int {
+	timeout := 300
+	if payloadTimeout != nil && *payloadTimeout > 0 {
+		timeout = *payloadTimeout
+		logrus.Debugf("Timeout: %d", timeout)
+	} else if payloadTimeout != nil {
+		logrus.Warnf("Invalid bootstrap recovery timeout %d seconds for admin %s, app %s. Falling back to default %d seconds", *payloadTimeout, adminName, appName, timeout)
+	}
+
+	maxTimeoutSeconds := int(maxBootstrapTimeout / time.Second)
+	if timeout > maxTimeoutSeconds {
+		logrus.Warnf(
+			"Bootstrap recovery timeout %d seconds exceeds max %d seconds for admin %s, app %s. Capping timeout.",
+			timeout,
+			maxTimeoutSeconds,
+			adminName,
+			appName,
+		)
+		timeout = maxTimeoutSeconds
+	}
+
+	return timeout
+}
+
+func calculateBootstrapRecoveryLockTTL(timeout time.Duration) time.Duration {
+	lockTTL := timeout + lockBuffer
+	if lockTTL < bootstrapRecoveryLockTTL {
+		return bootstrapRecoveryLockTTL
+	}
+	return lockTTL
 }

--- a/server/tuf/bootstrap/bootstrap_recovery_finalize.lua
+++ b/server/tuf/bootstrap/bootstrap_recovery_finalize.lua
@@ -1,0 +1,16 @@
+local current = redis.call("GET", KEYS[1])
+
+if ARGV[1] ~= "" then
+	if current == ARGV[1] then
+		redis.call("SET", KEYS[1], ARGV[2])
+		return 1
+	end
+	return 0
+end
+
+if not current then
+	redis.call("SET", KEYS[1], ARGV[2])
+	return 1
+end
+
+return 0

--- a/server/tuf/bootstrap/bootstrap_test.go
+++ b/server/tuf/bootstrap/bootstrap_test.go
@@ -874,6 +874,24 @@ func TestReleaseBootstrapLock_WithRedis_SettingsKeyFormats(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestReleaseBootstrapLock_DoesNotDeleteForeignBootstrapMarker(t *testing.T) {
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	taskID := "task-a"
+	adminName := "admin"
+	appName := "myapp"
+	bootstrapKey := "BOOTSTRAP_" + adminName + "_" + appName
+	mr.Set("pre-"+taskID, taskID)
+	mr.Set(bootstrapKey, "pre-task-b")
+
+	releaseBootstrapLock(client, taskID, adminName, appName)
+
+	val, err := client.Get(client.Context(), bootstrapKey).Result()
+	require.NoError(t, err)
+	assert.Equal(t, "pre-task-b", val, "cleanup must not delete marker for another task")
+}
+
 // To verify: In releaseBootstrapLock return early on Del error; test would still pass (miniredis Del succeeds).
 // Missing keys: Del on non-existent key returns no error in go-redis, so releaseBootstrapLock completes.
 func TestReleaseBootstrapLock_WithRedis_MissingKeys_NoError(t *testing.T) {
@@ -1095,6 +1113,30 @@ func TestPostBootstrapRecovery_WhenLockExists_ReturnsConflict(t *testing.T) {
 	assert.Equal(t, "Recovery already in progress for this admin and app", body["error"])
 }
 
+func TestPostBootstrapRecovery_WhenBootstrapActive_ReturnsConflict(t *testing.T) {
+	mockListMetadataForBootstrap(t, []string{"1.root.json"}, nil)
+	mockGetAllDelegatedRolesForRecovery(t, []string{}, nil)
+
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+	mr.Set("BOOTSTRAP_admin_myapp", "pre-bootstrap-task")
+	mr.Set("pre-bootstrap-task", "bootstrap-task")
+	c, w := makePostBootstrapRecoveryContext("admin", map[string]interface{}{"appName": "myapp"})
+
+	PostBootstrapRecovery(c, client)
+
+	assert.Equal(t, http.StatusConflict, w.Code)
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.Contains(t, body["error"], "Bootstrap already in progress")
+	for _, key := range mr.Keys() {
+		assert.False(t, strings.HasPrefix(key, "task:"), "no recovery task should be created while bootstrap is active")
+		assert.False(t, strings.HasPrefix(key, "RECOVERY_LOCK_admin_myapp"), "temporary recovery lock must be released on precheck conflict")
+	}
+}
+
 func TestPostBootstrapRecovery_WhenAlreadyRecovered_ReturnsConflictNoTask(t *testing.T) {
 	mockListMetadataForBootstrap(t, []string{"1.root.json"}, nil)
 	mockGetAllDelegatedRolesForRecovery(t, []string{"custom-role"}, nil)
@@ -1137,4 +1179,50 @@ func TestPostBootstrapRecovery_WhenAlreadyRecovered_ReturnsConflictNoTask(t *tes
 	for _, key := range allKeys {
 		assert.False(t, strings.HasPrefix(key, "task:"), "no recovery task should be created")
 	}
+}
+
+func TestRunBootstrapRecovery_AbortsWhenBootstrapMarkerChanged(t *testing.T) {
+	mockRecoverySettingsFunc(t, recoveredBootstrapSettings{
+		RootExpiration:      364,
+		RootThreshold:       2,
+		RootNumKeys:         2,
+		TargetsExpiration:   6,
+		TargetsThreshold:    1,
+		TargetsNumKeys:      1,
+		SnapshotExpiration:  6,
+		SnapshotThreshold:   1,
+		SnapshotNumKeys:     1,
+		TimestampExpiration: 1,
+		TimestampThreshold:  1,
+		TimestampNumKeys:    1,
+		TargetsOnlineKey:    true,
+		DelegatedExpiration: map[string]int{},
+	}, nil)
+
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+	adminName := "admin"
+	appName := "myapp"
+	taskID := "recovery-task"
+	lockKey := "RECOVERY_LOCK_" + adminName + "_" + appName
+	bootstrapKey := "BOOTSTRAP_" + adminName + "_" + appName
+	mr.Set(lockKey, taskID)
+	mr.Set(bootstrapKey, "pre-other-task")
+
+	runBootstrapRecovery(context.Background(), client, taskID, adminName, appName, lockKey, 30*time.Second, "pre-expected-task")
+
+	bootstrapValue, err := client.Get(context.Background(), bootstrapKey).Result()
+	require.NoError(t, err)
+	assert.Equal(t, "pre-other-task", bootstrapValue, "recovery must not clobber changed bootstrap marker")
+
+	taskData, err := client.Get(context.Background(), "task:"+taskID).Result()
+	require.NoError(t, err)
+	var taskStatus tasks.TaskStatus
+	require.NoError(t, json.Unmarshal([]byte(taskData), &taskStatus))
+	assert.Equal(t, tasks.TaskStateFailure, taskStatus.State)
+	require.NotNil(t, taskStatus.Result)
+	require.NotNil(t, taskStatus.Result.Error)
+	assert.Contains(t, *taskStatus.Result.Error, "bootstrap marker changed")
 }

--- a/server/tuf/bootstrap/bootstrap_test.go
+++ b/server/tuf/bootstrap/bootstrap_test.go
@@ -7,9 +7,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
+	"time"
 
 	"faynoSync/server/tuf/models"
+	tuf_storage "faynoSync/server/tuf/storage"
 	"faynoSync/server/tuf/tasks"
 
 	"github.com/alicebob/miniredis/v2"
@@ -21,12 +24,24 @@ import (
 
 func TestMain(m *testing.M) {
 	originalListMetadataForBootstrap := listMetadataForBootstrap
+	originalFindLatestMetadataBootstrap := findLatestMetadataBootstrap
+	originalDownloadMetadataForBootstrap := downloadMetadataForBootstrap
+	originalGetAllDelegatedRolesForRecovery := getAllDelegatedRolesForRecovery
+	originalRecoverSettingsFromStorageFn := recoverSettingsFromStorageFn
 	listMetadataForBootstrap = func(ctx context.Context, adminName, appName, prefix string) ([]string, error) {
 		return []string{}, nil
 	}
+	findLatestMetadataBootstrap = tuf_storage.FindLatestMetadataVersion
+	downloadMetadataForBootstrap = tuf_storage.DownloadMetadataFromS3
+	getAllDelegatedRolesForRecovery = tuf_storage.GetAllDelegatedRoles
+	recoverSettingsFromStorageFn = recoverSettingsFromStorage
 
 	code := m.Run()
 	listMetadataForBootstrap = originalListMetadataForBootstrap
+	findLatestMetadataBootstrap = originalFindLatestMetadataBootstrap
+	downloadMetadataForBootstrap = originalDownloadMetadataForBootstrap
+	getAllDelegatedRolesForRecovery = originalGetAllDelegatedRolesForRecovery
+	recoverSettingsFromStorageFn = originalRecoverSettingsFromStorageFn
 	os.Exit(code)
 }
 
@@ -925,4 +940,201 @@ func TestGetTaskStatusFromRedis_WithRedis_ReturnsStoredState(t *testing.T) {
 	got := getTaskStatusFromRedis(client, taskID)
 
 	assert.Equal(t, tasks.TaskStateFailure, got)
+}
+
+func makePostBootstrapRecoveryContext(username string, payload interface{}) (*gin.Context, *httptest.ResponseRecorder) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	raw, _ := json.Marshal(payload)
+	c.Request = httptest.NewRequest(http.MethodPost, "/tuf/v1/bootstrap/recovery", bytes.NewReader(raw))
+	c.Request.Header.Set("Content-Type", "application/json")
+	if username != "" {
+		c.Set("username", username)
+	}
+
+	return c, w
+}
+
+func mockRecoverySettingsFunc(t *testing.T, settings recoveredBootstrapSettings, err error) {
+	t.Helper()
+
+	original := recoverSettingsFromStorageFn
+	recoverSettingsFromStorageFn = func(ctx context.Context, adminName, appName string) (recoveredBootstrapSettings, error) {
+		return settings, err
+	}
+
+	t.Cleanup(func() {
+		recoverSettingsFromStorageFn = original
+	})
+}
+
+func mockGetAllDelegatedRolesForRecovery(t *testing.T, roles []string, err error) {
+	t.Helper()
+	original := getAllDelegatedRolesForRecovery
+	getAllDelegatedRolesForRecovery = func(ctx context.Context, adminName, appName string) ([]string, error) {
+		return roles, err
+	}
+	t.Cleanup(func() {
+		getAllDelegatedRolesForRecovery = original
+	})
+}
+
+func TestPostBootstrapRecovery_NilRedis_ReturnsServiceUnavailable(t *testing.T) {
+	c, w := makePostBootstrapRecoveryContext("admin", map[string]interface{}{"appName": "myapp"})
+	PostBootstrapRecovery(c, nil)
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+func TestPostBootstrapRecovery_MissingAppName_ReturnsBadRequest(t *testing.T) {
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+	c, w := makePostBootstrapRecoveryContext("admin", map[string]interface{}{})
+	PostBootstrapRecovery(c, client)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestPostBootstrapRecovery_RecoversRedisKeysAndSetsTask(t *testing.T) {
+	mockListMetadataForBootstrap(t, []string{"1.root.json"}, nil)
+	mockGetAllDelegatedRolesForRecovery(t, []string{"custom-role"}, nil)
+	mockRecoverySettingsFunc(t, recoveredBootstrapSettings{
+		RootExpiration:      364,
+		RootThreshold:       2,
+		RootNumKeys:         2,
+		TargetsExpiration:   6,
+		TargetsThreshold:    1,
+		TargetsNumKeys:      1,
+		SnapshotExpiration:  6,
+		SnapshotThreshold:   1,
+		SnapshotNumKeys:     1,
+		TimestampExpiration: 1,
+		TimestampThreshold:  1,
+		TimestampNumKeys:    1,
+		TargetsOnlineKey:    true,
+		DelegatedExpiration: map[string]int{"custom-role": 90},
+	}, nil)
+
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	c, w := makePostBootstrapRecoveryContext("admin", map[string]interface{}{"appName": "myapp"})
+
+	PostBootstrapRecovery(c, client)
+	assert.Equal(t, http.StatusAccepted, w.Code)
+
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	data := body["data"].(map[string]interface{})
+	taskID := data["task_id"].(string)
+	require.NotEmpty(t, taskID)
+
+	require.Eventually(t, func() bool {
+		taskData, err := client.Get(context.Background(), "task:"+taskID).Result()
+		if err != nil {
+			return false
+		}
+		var st tasks.TaskStatus
+		if err := json.Unmarshal([]byte(taskData), &st); err != nil {
+			return false
+		}
+		return st.State == tasks.TaskStateSuccess
+	}, 2*time.Second, 25*time.Millisecond)
+
+	bootstrapVal, err := client.Get(context.Background(), "BOOTSTRAP_admin_myapp").Result()
+	require.NoError(t, err)
+	assert.Equal(t, taskID, bootstrapVal)
+
+	requiredKeys := []string{
+		"ROOT_EXPIRATION_admin_myapp",
+		"ROOT_THRESHOLD_admin_myapp",
+		"ROOT_NUM_KEYS_admin_myapp",
+		"TARGETS_EXPIRATION_admin_myapp",
+		"TARGETS_THRESHOLD_admin_myapp",
+		"TARGETS_NUM_KEYS_admin_myapp",
+		"TARGETS_ONLINE_KEY_admin_myapp",
+		"SNAPSHOT_EXPIRATION_admin_myapp",
+		"SNAPSHOT_THRESHOLD_admin_myapp",
+		"SNAPSHOT_NUM_KEYS_admin_myapp",
+		"TIMESTAMP_EXPIRATION_admin_myapp",
+		"TIMESTAMP_THRESHOLD_admin_myapp",
+		"TIMESTAMP_NUM_KEYS_admin_myapp",
+		"custom-role_EXPIRATION_admin_myapp",
+		"ROOT_SIGNING_admin_myapp",
+	}
+	for _, key := range requiredKeys {
+		_, err := client.Get(context.Background(), key).Result()
+		require.NoError(t, err, "expected key %s", key)
+	}
+	recoveredTaskData, err := client.Get(context.Background(), "task:"+taskID).Result()
+	require.NoError(t, err)
+	var recoveredTask tasks.TaskStatus
+	require.NoError(t, json.Unmarshal([]byte(recoveredTaskData), &recoveredTask))
+	require.NotNil(t, recoveredTask.Result)
+	require.NotNil(t, recoveredTask.Result.Task)
+	assert.Equal(t, tasks.TaskNameBootstrapRecovery, *recoveredTask.Result.Task)
+}
+
+func TestPostBootstrapRecovery_WhenLockExists_ReturnsConflict(t *testing.T) {
+	mockListMetadataForBootstrap(t, []string{"1.root.json"}, nil)
+	mockGetAllDelegatedRolesForRecovery(t, []string{}, nil)
+
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+	mr.Set("RECOVERY_LOCK_admin_myapp", "other-task")
+	c, w := makePostBootstrapRecoveryContext("admin", map[string]interface{}{"appName": "myapp"})
+	PostBootstrapRecovery(c, client)
+
+	assert.Equal(t, http.StatusConflict, w.Code)
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, "Recovery already in progress for this admin and app", body["error"])
+}
+
+func TestPostBootstrapRecovery_WhenAlreadyRecovered_ReturnsConflictNoTask(t *testing.T) {
+	mockListMetadataForBootstrap(t, []string{"1.root.json"}, nil)
+	mockGetAllDelegatedRolesForRecovery(t, []string{"custom-role"}, nil)
+
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+	keys := map[string]string{
+		"BOOTSTRAP_admin_myapp":              "done-task",
+		"ROOT_EXPIRATION_admin_myapp":        "364",
+		"ROOT_THRESHOLD_admin_myapp":         "2",
+		"ROOT_NUM_KEYS_admin_myapp":          "2",
+		"TARGETS_EXPIRATION_admin_myapp":     "6",
+		"TARGETS_THRESHOLD_admin_myapp":      "1",
+		"TARGETS_NUM_KEYS_admin_myapp":       "1",
+		"TARGETS_ONLINE_KEY_admin_myapp":     "1",
+		"SNAPSHOT_EXPIRATION_admin_myapp":    "6",
+		"SNAPSHOT_THRESHOLD_admin_myapp":     "1",
+		"SNAPSHOT_NUM_KEYS_admin_myapp":      "1",
+		"TIMESTAMP_EXPIRATION_admin_myapp":   "1",
+		"TIMESTAMP_THRESHOLD_admin_myapp":    "1",
+		"TIMESTAMP_NUM_KEYS_admin_myapp":     "1",
+		"ROOT_SIGNING_admin_myapp":           "",
+		"custom-role_EXPIRATION_admin_myapp": "90",
+	}
+	for key, val := range keys {
+		mr.Set(key, val)
+	}
+
+	c, w := makePostBootstrapRecoveryContext("admin", map[string]interface{}{"appName": "myapp"})
+	PostBootstrapRecovery(c, client)
+
+	assert.Equal(t, http.StatusConflict, w.Code)
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, "Recovery not required: Redis state is already complete and consistent", body["error"])
+
+	allKeys := mr.Keys()
+	for _, key := range allKeys {
+		assert.False(t, strings.HasPrefix(key, "task:"), "no recovery task should be created")
+	}
 }

--- a/server/tuf/bootstrap/bootstrap_test.go
+++ b/server/tuf/bootstrap/bootstrap_test.go
@@ -960,6 +960,43 @@ func TestGetTaskStatusFromRedis_WithRedis_ReturnsStoredState(t *testing.T) {
 	assert.Equal(t, tasks.TaskStateFailure, got)
 }
 
+func TestGetTaskStatusFromRedisWithFound_KeyNotFound_ReturnsPendingAndNotFound(t *testing.T) {
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+	state, exists := getTaskStatusFromRedisWithFound(client, "nonexistent-task")
+
+	assert.Equal(t, tasks.TaskStatePending, state)
+	assert.False(t, exists)
+}
+
+func TestGetTaskStatusFromRedisWithFound_WithRedis_ReturnsStoredStateAndFound(t *testing.T) {
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	taskID := "task-success"
+	taskStatusJSON, _ := json.Marshal(tasks.TaskStatus{State: tasks.TaskStateSuccess})
+	mr.Set("task:"+taskID, string(taskStatusJSON))
+
+	state, exists := getTaskStatusFromRedisWithFound(client, taskID)
+
+	assert.Equal(t, tasks.TaskStateSuccess, state)
+	assert.True(t, exists)
+}
+
+func TestIsBootstrapTaskActive_PreMarkerWithoutPreLockAndWithoutTaskRecord_ReturnsInactive(t *testing.T) {
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+
+	active, taskID, err := isBootstrapTaskActive(context.Background(), client, "pre-missing-task")
+
+	require.NoError(t, err)
+	assert.False(t, active)
+	assert.Equal(t, "missing-task", taskID)
+}
+
 func makePostBootstrapRecoveryContext(username string, payload interface{}) (*gin.Context, *httptest.ResponseRecorder) {
 	gin.SetMode(gin.TestMode)
 	w := httptest.NewRecorder()

--- a/server/tuf/bootstrap/settings.go
+++ b/server/tuf/bootstrap/settings.go
@@ -3,10 +3,81 @@ package bootstrap
 import (
 	"context"
 	"faynoSync/server/tuf/models"
+	"fmt"
 
 	"github.com/go-redis/redis/v8"
 	"github.com/sirupsen/logrus"
 )
+
+type recoveredBootstrapSettings struct {
+	RootExpiration      int
+	RootThreshold       int
+	RootNumKeys         int
+	TargetsExpiration   int
+	TargetsThreshold    int
+	TargetsNumKeys      int
+	SnapshotExpiration  int
+	SnapshotThreshold   int
+	SnapshotNumKeys     int
+	TimestampExpiration int
+	TimestampThreshold  int
+	TimestampNumKeys    int
+	TargetsOnlineKey    bool
+	DelegatedExpiration map[string]int
+}
+
+func saveRecoveredSettings(
+	redisClient *redis.Client,
+	adminName string,
+	appName string,
+	settings recoveredBootstrapSettings,
+) error {
+	if redisClient == nil {
+		return fmt.Errorf("redis client is nil")
+	}
+
+	ctx := context.Background()
+	keySuffix := adminName
+	if appName != "" {
+		keySuffix = adminName + "_" + appName
+	}
+
+	writeKey := func(key string, value interface{}) error {
+		return redisClient.Set(ctx, key, value, 0).Err()
+	}
+
+	coreSettings := map[string]interface{}{
+		"ROOT_EXPIRATION_" + keySuffix:      settings.RootExpiration,
+		"ROOT_THRESHOLD_" + keySuffix:       settings.RootThreshold,
+		"ROOT_NUM_KEYS_" + keySuffix:        settings.RootNumKeys,
+		"TARGETS_EXPIRATION_" + keySuffix:   settings.TargetsExpiration,
+		"TARGETS_THRESHOLD_" + keySuffix:    settings.TargetsThreshold,
+		"TARGETS_NUM_KEYS_" + keySuffix:     settings.TargetsNumKeys,
+		"TARGETS_ONLINE_KEY_" + keySuffix:   settings.TargetsOnlineKey,
+		"SNAPSHOT_EXPIRATION_" + keySuffix:  settings.SnapshotExpiration,
+		"SNAPSHOT_THRESHOLD_" + keySuffix:   settings.SnapshotThreshold,
+		"SNAPSHOT_NUM_KEYS_" + keySuffix:    settings.SnapshotNumKeys,
+		"TIMESTAMP_EXPIRATION_" + keySuffix: settings.TimestampExpiration,
+		"TIMESTAMP_THRESHOLD_" + keySuffix:  settings.TimestampThreshold,
+		"TIMESTAMP_NUM_KEYS_" + keySuffix:   settings.TimestampNumKeys,
+		"ROOT_SIGNING_" + keySuffix:         "",
+	}
+
+	for key, value := range coreSettings {
+		if err := writeKey(key, value); err != nil {
+			return fmt.Errorf("failed to save %s: %w", key, err)
+		}
+	}
+
+	for roleName, expiration := range settings.DelegatedExpiration {
+		key := fmt.Sprintf("%s_EXPIRATION_%s", roleName, keySuffix)
+		if err := writeKey(key, expiration); err != nil {
+			return fmt.Errorf("failed to save delegated expiration %s: %w", key, err)
+		}
+	}
+
+	return nil
+}
 
 // saveSettings saves bootstrap settings to Redis
 func saveSettings(redisClient *redis.Client, adminName string, appName string, payload *models.BootstrapPayload) {
@@ -16,7 +87,6 @@ func saveSettings(redisClient *redis.Client, adminName string, appName string, p
 		return
 	}
 
-	ctx := context.Background()
 	roles := payload.Settings.Roles
 
 	rootMetadata, exists := payload.Metadata["root"]
@@ -60,57 +130,26 @@ func saveSettings(redisClient *redis.Client, adminName string, appName string, p
 		}
 	}
 
-	// Build key suffix: adminName_appName if appName is provided, otherwise just adminName
-	keySuffix := adminName
-	if appName != "" {
-		keySuffix = adminName + "_" + appName
+	recovered := recoveredBootstrapSettings{
+		RootExpiration:      roles.Root.Expiration,
+		RootThreshold:       rootThreshold,
+		RootNumKeys:         rootNumKeys,
+		TargetsExpiration:   roles.Targets.Expiration,
+		TargetsThreshold:    targetsThreshold,
+		TargetsNumKeys:      targetsNumKeys,
+		SnapshotExpiration:  roles.Snapshot.Expiration,
+		SnapshotThreshold:   snapshotThreshold,
+		SnapshotNumKeys:     snapshotNumKeys,
+		TimestampExpiration: roles.Timestamp.Expiration,
+		TimestampThreshold:  timestampThreshold,
+		TimestampNumKeys:    timestampNumKeys,
+		TargetsOnlineKey:    true,
+		DelegatedExpiration: map[string]int{},
 	}
 
-	// Save ROOT settings (with admin name and app name suffix)
-	if err := redisClient.Set(ctx, "ROOT_EXPIRATION_"+keySuffix, roles.Root.Expiration, 0).Err(); err != nil {
-		logrus.Errorf("Failed to save ROOT_EXPIRATION for admin %s, app %s: %v", adminName, appName, err)
-	}
-	if err := redisClient.Set(ctx, "ROOT_THRESHOLD_"+keySuffix, rootThreshold, 0).Err(); err != nil {
-		logrus.Errorf("Failed to save ROOT_THRESHOLD for admin %s, app %s: %v", adminName, appName, err)
-	}
-	if err := redisClient.Set(ctx, "ROOT_NUM_KEYS_"+keySuffix, rootNumKeys, 0).Err(); err != nil {
-		logrus.Errorf("Failed to save ROOT_NUM_KEYS for admin %s, app %s: %v", adminName, appName, err)
-	}
-
-	// Save TARGETS settings (from root metadata roles)
-	if err := redisClient.Set(ctx, "TARGETS_EXPIRATION_"+keySuffix, roles.Targets.Expiration, 0).Err(); err != nil {
-		logrus.Errorf("Failed to save TARGETS_EXPIRATION for admin %s, app %s: %v", adminName, appName, err)
-	}
-	if err := redisClient.Set(ctx, "TARGETS_THRESHOLD_"+keySuffix, targetsThreshold, 0).Err(); err != nil {
-		logrus.Errorf("Failed to save TARGETS_THRESHOLD for admin %s, app %s: %v", adminName, appName, err)
-	}
-	if err := redisClient.Set(ctx, "TARGETS_NUM_KEYS_"+keySuffix, targetsNumKeys, 0).Err(); err != nil {
-		logrus.Errorf("Failed to save TARGETS_NUM_KEYS for admin %s, app %s: %v", adminName, appName, err)
-	}
-	if err := redisClient.Set(ctx, "TARGETS_ONLINE_KEY_"+keySuffix, true, 0).Err(); err != nil {
-		logrus.Errorf("Failed to save TARGETS_ONLINE_KEY for admin %s, app %s: %v", adminName, appName, err)
-	}
-
-	// Save SNAPSHOT settings (from root metadata roles)
-	if err := redisClient.Set(ctx, "SNAPSHOT_EXPIRATION_"+keySuffix, roles.Snapshot.Expiration, 0).Err(); err != nil {
-		logrus.Errorf("Failed to save SNAPSHOT_EXPIRATION for admin %s, app %s: %v", adminName, appName, err)
-	}
-	if err := redisClient.Set(ctx, "SNAPSHOT_THRESHOLD_"+keySuffix, snapshotThreshold, 0).Err(); err != nil {
-		logrus.Errorf("Failed to save SNAPSHOT_THRESHOLD for admin %s, app %s: %v", adminName, appName, err)
-	}
-	if err := redisClient.Set(ctx, "SNAPSHOT_NUM_KEYS_"+keySuffix, snapshotNumKeys, 0).Err(); err != nil {
-		logrus.Errorf("Failed to save SNAPSHOT_NUM_KEYS for admin %s, app %s: %v", adminName, appName, err)
-	}
-
-	// Save TIMESTAMP settings (from root metadata roles)
-	if err := redisClient.Set(ctx, "TIMESTAMP_EXPIRATION_"+keySuffix, roles.Timestamp.Expiration, 0).Err(); err != nil {
-		logrus.Errorf("Failed to save TIMESTAMP_EXPIRATION for admin %s, app %s: %v", adminName, appName, err)
-	}
-	if err := redisClient.Set(ctx, "TIMESTAMP_THRESHOLD_"+keySuffix, timestampThreshold, 0).Err(); err != nil {
-		logrus.Errorf("Failed to save TIMESTAMP_THRESHOLD for admin %s, app %s: %v", adminName, appName, err)
-	}
-	if err := redisClient.Set(ctx, "TIMESTAMP_NUM_KEYS_"+keySuffix, timestampNumKeys, 0).Err(); err != nil {
-		logrus.Errorf("Failed to save TIMESTAMP_NUM_KEYS for admin %s, app %s: %v", adminName, appName, err)
+	if err := saveRecoveredSettings(redisClient, adminName, appName, recovered); err != nil {
+		logrus.Errorf("Failed to save bootstrap settings for admin %s, app %s: %v", adminName, appName, err)
+		return
 	}
 
 	logrus.Debug("Successfully saved all bootstrap settings to Redis")

--- a/server/tuf/tasks/models.go
+++ b/server/tuf/tasks/models.go
@@ -27,6 +27,7 @@ const (
 	TaskNameAddArtifacts              TaskName = "add_artifacts"
 	TaskNameRemoveArtifacts           TaskName = "remove_artifacts"
 	TaskNameBootstrap                 TaskName = "bootstrap"
+	TaskNameBootstrapRecovery         TaskName = "bootstrap_recovery"
 	TaskNameUpdateSettings            TaskName = "update_settings"
 	TaskNamePublishArtifacts          TaskName = "publish_artifacts"
 	TaskNameMetadataUpdate            TaskName = "metadata_update"

--- a/server/tuf/tuf.go
+++ b/server/tuf/tuf.go
@@ -25,6 +25,9 @@ func SetupRoutes(router *gin.Engine, authMiddleware gin.HandlerFunc, mongoDataba
 	router.POST("/tuf/v1/bootstrap", authMiddleware, adminMiddleware, func(c *gin.Context) {
 		bootstrap.PostBootstrap(c, redisClient)
 	})
+	router.POST("/tuf/v1/bootstrap/recovery", authMiddleware, adminMiddleware, func(c *gin.Context) {
+		bootstrap.PostBootstrapRecovery(c, redisClient)
+	})
 	router.GET("/tuf/v1/task", authMiddleware, appEditPermissionMiddleware, resolveOwnerMiddleware, func(c *gin.Context) {
 		tasks.GetTask(c, redisClient)
 	})

--- a/server/tuf/tuf.go
+++ b/server/tuf/tuf.go
@@ -16,6 +16,8 @@ import (
 
 func SetupRoutes(router *gin.Engine, authMiddleware gin.HandlerFunc, mongoDatabase *mongo.Database, redisClient *redis.Client, appRepository mongod.AppRepository) {
 	adminMiddleware := utils.AdminOnlyMiddleware(mongoDatabase)
+	appEditPermissionMiddleware := utils.CheckPermission(utils.PermissionEdit, utils.ResourceApps, mongoDatabase)
+	resolveOwnerMiddleware := utils.ResolveOwnerMiddleware(mongoDatabase)
 
 	router.GET("/tuf/v1/bootstrap", authMiddleware, adminMiddleware, func(c *gin.Context) {
 		bootstrap.GetBootstrapStatus(c, redisClient)
@@ -23,13 +25,13 @@ func SetupRoutes(router *gin.Engine, authMiddleware gin.HandlerFunc, mongoDataba
 	router.POST("/tuf/v1/bootstrap", authMiddleware, adminMiddleware, func(c *gin.Context) {
 		bootstrap.PostBootstrap(c, redisClient)
 	})
-	router.GET("/tuf/v1/task", authMiddleware, adminMiddleware, func(c *gin.Context) {
+	router.GET("/tuf/v1/task", authMiddleware, appEditPermissionMiddleware, resolveOwnerMiddleware, func(c *gin.Context) {
 		tasks.GetTask(c, redisClient)
 	})
-	router.POST("/tuf/v1/artifacts/publish", authMiddleware, adminMiddleware, func(c *gin.Context) {
+	router.POST("/tuf/v1/artifacts/publish", authMiddleware, appEditPermissionMiddleware, resolveOwnerMiddleware, func(c *gin.Context) {
 		artifacts.PostPublishArtifacts(c, redisClient, mongoDatabase)
 	})
-	router.POST("/tuf/v1/artifacts/delete", authMiddleware, adminMiddleware, func(c *gin.Context) {
+	router.POST("/tuf/v1/artifacts/delete", authMiddleware, appEditPermissionMiddleware, resolveOwnerMiddleware, func(c *gin.Context) {
 		artifacts.PostDeleteArtifacts(c, redisClient, mongoDatabase)
 	})
 	router.GET("/tuf/v1/config", authMiddleware, adminMiddleware, func(c *gin.Context) {

--- a/server/utils/owner.go
+++ b/server/utils/owner.go
@@ -1,0 +1,62 @@
+package utils
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"faynoSync/server/model"
+
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// Maybe use the same flow for main API?
+
+const ownerContextKey = "owner"
+
+func ResolveRequestOwner(ctx context.Context, username string, database *mongo.Database) (string, error) {
+	teamUsersCollection := database.Collection("team_users")
+	var teamUser model.TeamUser
+	err := teamUsersCollection.FindOne(ctx, bson.M{"username": username}).Decode(&teamUser)
+	if err == nil {
+		return teamUser.Owner, nil
+	}
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		return username, nil
+	}
+	return "", err
+}
+
+func ResolveOwnerMiddleware(database *mongo.Database) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		username, err := GetUsernameFromContext(c)
+		if err != nil {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+			c.Abort()
+			return
+		}
+
+		owner, err := ResolveRequestOwner(c.Request.Context(), username, database)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to resolve owner"})
+			c.Abort()
+			return
+		}
+
+		c.Set(ownerContextKey, owner)
+		c.Next()
+	}
+}
+
+func GetOwnerFromContext(c *gin.Context) (string, error) {
+	if owner, exists := c.Get(ownerContextKey); exists {
+		ownerString, ok := owner.(string)
+		if ok && ownerString != "" {
+			return ownerString, nil
+		}
+	}
+
+	return GetUsernameFromContext(c)
+}


### PR DESCRIPTION
## v1.5.11

### Features

- Added `POST /tuf/v1/bootstrap/recovery` to rebuild bootstrap Redis settings from persisted TUF metadata for already initialized repositories.
- Added asynchronous `bootstrap_recovery` task flow with lock protection, recovery prechecks, timeout support, and task status reporting.

### Security & Access Control

- Added RBAC edit permission checks for TUF task status, artifact publish, and artifact delete endpoints.
- Added owner resolution middleware for team users so TUF artifact operations run under resolved owner context.

### Reliability

- Unified bootstrap settings persistence and recovery via a shared Redis save path, including delegated role expirations and `ROOT_SIGNING` initialization.

### API Tooling

- Updated Postman collection with bootstrap recovery API request examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bootstrap recovery endpoint and async recovery task flow with lock, timeout, and status reporting.
  * Enforced RBAC edit permission for task status, artifact publish, and artifact delete.
  * Added owner-resolution for team users so artifact ops run under resolved owner context.
  * Unified bootstrap settings persistence/recovery and delegated-role expiration handling.
  * Postman collection updated with bootstrap recovery examples.

* **Documentation**
  * Changelog and roadmap updated to reflect new items and roadmap adjustments.

* **Tests**
  * Added recovery and bootstrap lock regression tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->