### PR TITLE
(release) v1.5.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## v1.5.16
+
+### Security (TUF)
+
+- Fixed snapshot lock key inconsistency that allowed concurrent artifact publish and force-online update to race and silently discard each other's snapshot changes.
+- Fixed silent verification skip in `PostMetadataSign` targets path: S3/unmarshal failures now surface as errors instead of being swallowed, preventing unverified metadata from advancing.
+- Fixed trusted metadata loaded from S3 without expiration check; expired metadata is now rejected before use.
+- Fixed root rotation staging that used fragile error string matching to detect wrong-version vs bad-signature failures.
+- Fixed `PostMetadataSign` Redis writes silently ignored on staging paths; errors are now propagated.
+- Fixed `loadTrustedRootMetadataFromS3` using raw `json.Unmarshal` instead of the library's `FromFile`; root is now loaded through the verified library path.
+
+### Fixes (TUF)
+
+- Fixed snapshot `MetaFile` entries omitting hashes; snapshot now includes `sha256` hash and length for all referenced metadata files.
+- Fixed missing root signature verification in the `thresholdReached` targets signing path.
+- Fixed `GetConfig` returning only the first custom role expiration due to a loop variable bug.
+- Fixed `RemoveArtifacts` loading root by hardcoded version 1 instead of the latest version.
+- Fixed duplicate signing logic in `removeArtifactsFromDelegatedRole`.
+- Fixed MongoDB artifact status updated before TUF operation succeeds; status is now written only after a successful TUF commit.
+- Fixed temporary directories created in `cwd` instead of system temp.
+- Fixed `HelperGetPathForTarget` panicking on `os.Getwd()` failure; returns error instead.
+- Fixed task records stored in Redis with no TTL.
+- Fixed `CalculateExpirationDays` silently returning 365 on parse failure; returns error instead.
+- Removed unused `ctx context.Context` parameter from delegation helpers.
+
+### Improvements (TUF)
+
+- Added `appName` validation to reject characters that could cause Redis key collisions or S3 path injection.
+- Replaced `KEYS` with `SCAN` in `GetMetadataSign` to avoid blocking Redis on large keyspaces.
+- Fixed `GetConfig` loop and `PutConfig` to respect online/offline mode for targets expiration.
+- Removed dead code: `GetBootstrapLocks`, `bootstrap()`, `bootstrapFinalize()`.
+
 ## v1.5.15
 
 ### Features

--- a/examples/tuf-client-go/client.go
+++ b/examples/tuf-client-go/client.go
@@ -36,9 +36,9 @@ import (
 // Adapted from the upstream go-tuf client example.
 // The values below are overridden for faynoSync endpoints and target layout.
 const (
-	metadataURL          = "http://cb-faynosync-s3-public.web.garage.localhost:3902/tuf_metadata/admin/tuf/"
+	metadataURL          = "http://cb-faynosync-s3-public.web.garage.localhost:3902/tuf_metadata/admin/test/"
 	targetsURL           = "http://cb-faynosync-s3-public.web.garage.localhost:3902/"
-	targetName           = "tuf-admin/nightly/darwin/arm64/tuf-0.0.0.2"
+	targetName           = "test-admin/nightly/darwin/arm64/test-0.0.0.2"
 	verbosity            = 4
 	generateRandomFolder = false
 )

--- a/server/tuf/artifacts/add.go
+++ b/server/tuf/artifacts/add.go
@@ -26,6 +26,19 @@ import (
 	tuf_utils "faynoSync/server/tuf/utils"
 )
 
+func metaFileFromPath(path string, version int64) (*metadata.MetaFiles, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s for hash computation: %w", path, err)
+	}
+	sum := sha256.Sum256(data)
+	return &metadata.MetaFiles{
+		Version: version,
+		Length:  int64(len(data)),
+		Hashes:  metadata.Hashes{"sha256": metadata.HexBytes(sum[:])},
+	}, nil
+}
+
 func AddArtifacts(
 	ctx context.Context,
 	redisClient *redis.Client,
@@ -44,11 +57,7 @@ func AddArtifacts(
 
 	keySuffix := adminName + "_" + appName
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("failed to get current working directory: %w", err)
-	}
-	tmpDir, err := os.MkdirTemp(cwd, "tmp-tuf-*")
+	tmpDir, err := os.MkdirTemp("", "tmp-tuf-*")
 	if err != nil {
 		return fmt.Errorf("failed to create temporary directory: %w", err)
 	}
@@ -166,7 +175,7 @@ func AddArtifacts(
 			artifactPaths = append(artifactPaths, artifact.Path)
 		}
 		pathsUpdated, err := delegations.UpdateDelegationPaths(
-			ctx, repo, roleName, artifactPaths, adminName,
+			repo, roleName, artifactPaths, adminName,
 		)
 		if err != nil {
 			logrus.Warnf("Failed to update delegation paths for role %s: %v", roleName, err)
@@ -323,7 +332,11 @@ func matchDelegatedPathPattern(pattern string, artifactPath string) (bool, error
 		return true, nil
 	}
 
-	// Preserve legacy delegation semantics where "prefix/*" is used as recursive prefix.
+	// Deliberate extension: "prefix/*" is treated as a recursive prefix.
+	// This diverges from the TUF spec glob (where * does not cross /), but all
+	// bootstrapped delegations use this convention (e.g. "test-admin/*" must
+	// match "test-admin/nightly/darwin/arm64/file"). Do not remove without
+	// re-bootstrapping all delegations to use "**" or pathHashPrefixes instead.
 	if strings.HasSuffix(pattern, "/*") {
 		prefix := strings.TrimSuffix(pattern, "*")
 		if strings.HasPrefix(artifactPath, prefix) {
@@ -471,7 +484,7 @@ func updateSnapshotAndTimestamp(
 	snapshotSigners []signature.Signer,
 	tmpDir string,
 ) error {
-	lockKey := fmt.Sprintf("LOCK_SNAPSHOT_%s", adminName)
+	lockKey := fmt.Sprintf("LOCK_SNAPSHOT_%s_%s", adminName, appName)
 	lockTTL := 300 * time.Second
 	maxWaitTime := 500 * time.Second
 
@@ -560,7 +573,17 @@ func updateSnapshotAndTimestamp(
 		delegation := repo.Targets(roleName)
 		if delegation != nil && delegation.Signed.Version > 0 {
 			metaFilename := fmt.Sprintf("%s.json", roleName)
-			snapshotMeta[metaFilename] = metadata.MetaFile(int64(delegation.Signed.Version))
+			delegationFile := filepath.Join(tmpDir, fmt.Sprintf("%d.%s.json", delegation.Signed.Version, roleName))
+			if _, statErr := os.Stat(delegationFile); statErr != nil {
+				if err := delegation.ToFile(delegationFile, true); err != nil {
+					return fmt.Errorf("failed to write %s for hash computation: %w", roleName, err)
+				}
+			}
+			mf, err := metaFileFromPath(delegationFile, int64(delegation.Signed.Version))
+			if err != nil {
+				return fmt.Errorf("failed to compute hash for %s: %w", roleName, err)
+			}
+			snapshotMeta[metaFilename] = mf
 			logrus.Debugf("Updated snapshot meta for role %s (version %d)", roleName, delegation.Signed.Version)
 		} else {
 			logrus.Warnf("Role %s not found in repo or has invalid version, skipping snapshot update", roleName)
@@ -570,7 +593,17 @@ func updateSnapshotAndTimestamp(
 	// Always update targets.json in snapshot
 	targets := repo.Targets("targets")
 	if targets != nil {
-		snapshotMeta["targets.json"] = metadata.MetaFile(int64(targets.Signed.Version))
+		targetsFile := filepath.Join(tmpDir, fmt.Sprintf("%d.targets.json", targets.Signed.Version))
+		if _, statErr := os.Stat(targetsFile); statErr != nil {
+			if err := targets.ToFile(targetsFile, true); err != nil {
+				return fmt.Errorf("failed to write targets for hash computation: %w", err)
+			}
+		}
+		mf, err := metaFileFromPath(targetsFile, int64(targets.Signed.Version))
+		if err != nil {
+			return fmt.Errorf("failed to compute targets hash for snapshot: %w", err)
+		}
+		snapshotMeta["targets.json"] = mf
 	}
 
 	repo.Snapshot().Signed.Version++
@@ -637,8 +670,17 @@ func updateTimestamp(
 
 	snapshot := repo.Snapshot()
 	if snapshot != nil {
-		snapshotMetaFile := metadata.MetaFile(int64(snapshot.Signed.Version))
-		timestampMeta["snapshot.json"] = snapshotMetaFile
+		snapshotFile := filepath.Join(tmpDir, fmt.Sprintf("%d.snapshot.json", snapshot.Signed.Version))
+		if _, statErr := os.Stat(snapshotFile); statErr != nil {
+			if err := snapshot.ToFile(snapshotFile, true); err != nil {
+				return fmt.Errorf("failed to write snapshot for hash computation: %w", err)
+			}
+		}
+		mf, err := metaFileFromPath(snapshotFile, int64(snapshot.Signed.Version))
+		if err != nil {
+			return fmt.Errorf("failed to compute snapshot hash for timestamp: %w", err)
+		}
+		timestampMeta["snapshot.json"] = mf
 	}
 	if loadedTimestamp {
 		repo.Timestamp().Signed.Version++

--- a/server/tuf/artifacts/add_test.go
+++ b/server/tuf/artifacts/add_test.go
@@ -644,7 +644,11 @@ func TestGetRoleForArtifactPath_MultipleRoles_FirstRoleMatches_ReturnsFirst(t *t
 	assert.Equal(t, "updates", roleName)
 }
 
-func TestGetRoleForArtifactPath_SingleWildcardPatternMatchesNestedPath_ReturnsRoleName(t *testing.T) {
+// TUF spec glob semantics: * does not cross directory separators, so a
+// deeply nested path does not match "prefix/*".
+// Deliberate extension: "prefix/*" is recursive in this implementation.
+// "tuf-ku9n/*" must match deeply nested paths like "tuf-ku9n/nightly/linux/amd64/file".
+func TestGetRoleForArtifactPath_WildcardPatternMatchesNestedPath(t *testing.T) {
 	repo := repoWithTargetsAndOneRoleForGetRole("default", []string{"tuf-ku9n/*"})
 
 	roleName, err := getRoleForArtifactPath(repo, "tuf-ku9n/nightly/linux/amd64/tuf-0.0.0.1.js")
@@ -696,7 +700,9 @@ func TestMatchesRole_SecondPathMatches_ReturnsTrue(t *testing.T) {
 	assert.True(t, got)
 }
 
-func TestMatchesRole_SingleWildcardPatternMatchesNestedPath_ReturnsTrue(t *testing.T) {
+// Deliberate extension: "prefix/*" is recursive in this implementation.
+// "tuf-ku9n/*" must match deeply nested paths like "tuf-ku9n/nightly/linux/amd64/file".
+func TestMatchesRole_WildcardPatternMatchesNestedPath(t *testing.T) {
 	role := &tuf_metadata.DelegatedRole{Name: "default", KeyIDs: []string{"k1"}, Threshold: 1, Paths: []string{"tuf-ku9n/*"}}
 	got := matchesRole("tuf-ku9n/nightly/linux/amd64/tuf-0.0.0.1.js", role)
 	assert.True(t, got)
@@ -1056,7 +1062,7 @@ func TestUpdateSnapshotAndTimestamp_RedisSetNXError_ReturnsError(t *testing.T) {
 func TestUpdateSnapshotAndTimestamp_LockHeld_Timeout_ReturnsError(t *testing.T) {
 	mr := miniredis.RunT(t)
 	defer mr.Close()
-	mr.Set("LOCK_SNAPSHOT_"+testAdminName, "locked")
+	mr.Set("LOCK_SNAPSHOT_"+testAdminName+"_"+testAppName, "locked")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
 	defer cancel()

--- a/server/tuf/artifacts/delete.go
+++ b/server/tuf/artifacts/delete.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/go-redis/redis/v8"
+	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/sirupsen/logrus"
 	"github.com/theupdateframework/go-tuf/v2/examples/repository/repository"
 	"github.com/theupdateframework/go-tuf/v2/metadata"
@@ -38,11 +39,7 @@ func RemoveArtifacts(
 
 	keySuffix := adminName + "_" + appName
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("failed to get current working directory: %w", err)
-	}
-	tmpDir, err := os.MkdirTemp(cwd, "tmp-tuf-*")
+	tmpDir, err := os.MkdirTemp("", "tmp-tuf-*")
 	if err != nil {
 		return fmt.Errorf("failed to create temporary directory: %w", err)
 	}
@@ -51,9 +48,16 @@ func RemoveArtifacts(
 	repo := repository.New()
 
 	rootPath := filepath.Join(tmpDir, "root.json")
-	if err := tuf_storage.DownloadMetadataFromS3(ctx, adminName, appName, "1.root.json", rootPath); err != nil {
-		if err2 := tuf_storage.DownloadMetadataFromS3(ctx, adminName, appName, "root.json", rootPath); err2 != nil {
-			return fmt.Errorf("failed to download root metadata: %w", err)
+	_, latestRootFilename, err := tuf_storage.FindLatestMetadataVersion(ctx, adminName, appName, "root")
+	if err != nil {
+		if err := tuf_storage.DownloadMetadataFromS3(ctx, adminName, appName, "root.json", rootPath); err != nil {
+			if err2 := tuf_storage.DownloadMetadataFromS3(ctx, adminName, appName, "1.root.json", rootPath); err2 != nil {
+				return fmt.Errorf("failed to download root metadata (tried root.json and 1.root.json): %w", err)
+			}
+		}
+	} else {
+		if err := tuf_storage.DownloadMetadataFromS3(ctx, adminName, appName, latestRootFilename, rootPath); err != nil {
+			return fmt.Errorf("failed to download latest root metadata: %w", err)
 		}
 	}
 
@@ -151,7 +155,7 @@ func RemoveArtifacts(
 			artifactPaths = append(artifactPaths, artifact.Path)
 		}
 		pathsRemoved, err := delegations.RemoveDelegationPaths(
-			ctx, repo, roleName, artifactPaths, adminName,
+			repo, roleName, artifactPaths, adminName,
 		)
 		if err != nil {
 			logrus.Warnf("Failed to remove delegation paths for role %s: %v", roleName, err)
@@ -329,35 +333,20 @@ func removeArtifactsFromDelegatedRole(
 	if len(roleKeyIDs) == 0 {
 		return false, fmt.Errorf("no key IDs found for delegated role %s", roleName)
 	}
-	if roleThreshold < 1 {
-		roleThreshold = 1
-	}
-	seenKeyID := make(map[string]bool)
-	keysToSign := make([]string, 0, roleThreshold)
-	for _, keyID := range roleKeyIDs {
-		if seenKeyID[keyID] {
-			continue
-		}
-		seenKeyID[keyID] = true
-		keysToSign = append(keysToSign, keyID)
-		if len(keysToSign) == roleThreshold {
-			break
-		}
-	}
-	if len(keysToSign) < roleThreshold {
-		return false, fmt.Errorf("not enough distinct keys for delegated role %s: need %d, got %d", roleName, roleThreshold, len(keysToSign))
-	}
 
-	for _, delegationKeyID := range keysToSign {
-		delegationSigner, err := signing.BuildSignerFromPrivateKeyFile(delegationKeyID, delegationKeyID)
-		if err != nil {
-			return false, fmt.Errorf("failed to load delegation private key %s for role %s: %w", delegationKeyID, roleName, err)
-		}
-
-		if _, err := repo.Targets(roleName).Sign(delegationSigner); err != nil {
-			return false, fmt.Errorf("failed to sign %s metadata with key %s: %w", roleName, delegationKeyID, err)
-		}
-		logrus.Debugf("Successfully signed delegated role %s with key %s", roleName, delegationKeyID)
+	if _, err := signing.LoadAndSignDelegation(
+		roleName,
+		roleKeyIDs,
+		roleThreshold,
+		func(s signature.Signer, keyID string) error {
+			_, err := repo.Targets(roleName).Sign(s)
+			if err == nil {
+				logrus.Debugf("Successfully signed delegated role %s with key %s", roleName, keyID)
+			}
+			return err
+		},
+	); err != nil {
+		return false, fmt.Errorf("failed to sign delegated role %s: %w", roleName, err)
 	}
 
 	newDelegationFilename := fmt.Sprintf("%d.%s.json", delegation.Signed.Version, roleName)

--- a/server/tuf/artifacts/delete_test.go
+++ b/server/tuf/artifacts/delete_test.go
@@ -275,7 +275,8 @@ func TestRemoveArtifacts_DownloadRootFails_ReturnsError(t *testing.T) {
 	}, testTaskID)
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to download root metadata")
+	assert.Contains(t, err.Error(), "failed to download")
+	assert.Contains(t, err.Error(), "root")
 }
 
 // To verify: In RemoveArtifacts change error handling for FindLatestMetadataVersion (targets); test will fail (no error or wrong message).
@@ -667,7 +668,7 @@ func TestRemoveArtifactsFromDelegatedRole_NotEnoughDistinctKeys_ReturnsError(t *
 	_, err := removeArtifactsFromDelegatedRole(ctx, repo, "updates", artifacts, testAdminName, testAppName, redisClient, tmpDir)
 
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not enough distinct keys for delegated role updates")
+	assert.Contains(t, err.Error(), "not enough distinct keys")
 	assert.Contains(t, err.Error(), "need 2, got 1")
 }
 
@@ -718,7 +719,8 @@ func TestRemoveArtifactsFromDelegatedRole_LoadDelegationKeyFails_ReturnsError(t 
 
 	require.Error(t, err)
 	assert.False(t, removed)
-	assert.Contains(t, err.Error(), "failed to load delegation private key")
+	assert.Contains(t, err.Error(), "failed to load")
+	assert.Contains(t, err.Error(), "private key")
 }
 
 // To verify: In removeArtifactsFromDelegatedRole skip UploadMetadataToS3 error; test will fail (no error or wrong message).

--- a/server/tuf/artifacts/handlers.go
+++ b/server/tuf/artifacts/handlers.go
@@ -414,8 +414,6 @@ func PostDeleteArtifacts(c *gin.Context, redisClient *redis.Client, mongoDatabas
 		logrus.Warnf("Failed to update task state to RUNNING: %v", err)
 	}
 
-	updateArtifactsTUFStatusToDeleted(ctx, mongoDatabase, appDoc.AppID, payload.Version, owner, artifactsToDelete, &taskID)
-
 	go func() {
 		ctx := context.Background()
 		if err := RemoveArtifacts(
@@ -441,7 +439,9 @@ func PostDeleteArtifacts(c *gin.Context, redisClient *redis.Client, mongoDatabas
 			if err := tasks.SaveTaskStatus(redisClient, taskID, tasks.TaskStateFailure, result); err != nil {
 				logrus.Errorf("Failed to save error task status: %v", err)
 			}
+			return
 		}
+		updateArtifactsTUFStatusToDeleted(ctx, mongoDatabase, appDoc.AppID, payload.Version, owner, artifactsToDelete, &taskID)
 	}()
 
 	artifactPaths := make([]string, len(tufArtifacts))

--- a/server/tuf/bootstrap/bootstrap.go
+++ b/server/tuf/bootstrap/bootstrap.go
@@ -9,6 +9,7 @@ import (
 	"faynoSync/server/tuf/models"
 	tuf_storage "faynoSync/server/tuf/storage"
 	"faynoSync/server/tuf/tasks"
+	tuf_utils "faynoSync/server/tuf/utils"
 	"faynoSync/server/utils"
 	"fmt"
 	"net/http"
@@ -141,6 +142,10 @@ func GetBootstrapStatus(c *gin.Context, redisClient *redis.Client) {
 		})
 		return
 	}
+	if err := tuf_utils.ValidateAppName(appName); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
 
 	isInitialized, err := hasPersistedRootMetadata(context.Background(), adminName, appName)
 	if err != nil {
@@ -203,99 +208,6 @@ func GetBootstrapStatus(c *gin.Context, redisClient *redis.Client) {
 	})
 }
 
-// Seems like only for testing purposes (?)
-func GetBootstrapLocks(c *gin.Context, redisClient *redis.Client) {
-	adminName, err := utils.GetUsernameFromContext(c)
-	if err != nil {
-		logrus.Errorf("Failed to get admin name from context: %v", err)
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
-		return
-	}
-
-	appName := c.Query("appName")
-	if appName == "" {
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": "appName query parameter is required",
-		})
-		return
-	}
-
-	if redisClient == nil {
-		c.JSON(http.StatusServiceUnavailable, gin.H{
-			"error": "Redis client is not available",
-		})
-		return
-	}
-
-	ctx := context.Background()
-	locks := make(map[string]interface{})
-
-	bootstrapKey := "BOOTSTRAP_" + adminName + "_" + appName
-	bootstrapValue, err := redisClient.Get(ctx, bootstrapKey).Result()
-	if err == nil {
-		locks["BOOTSTRAP"] = gin.H{
-			"key":    bootstrapKey,
-			"value":  bootstrapValue,
-			"exists": true,
-		}
-		logrus.Debugf("Found BOOTSTRAP lock for admin %s, app %s: %s", adminName, appName, bootstrapValue)
-	} else {
-		locks["BOOTSTRAP"] = gin.H{
-			"key":    bootstrapKey,
-			"value":  nil,
-			"exists": false,
-		}
-		logrus.Debugf("No BOOTSTRAP lock found for admin %s, app %s", adminName, appName)
-	}
-
-	preLockKeys, err := scanKeys(ctx, redisClient, "pre-*")
-	if err == nil {
-		preLocks := make([]map[string]interface{}, 0)
-		for _, key := range preLockKeys {
-			value, err := redisClient.Get(ctx, key).Result()
-			if err == nil {
-				preLocks = append(preLocks, map[string]interface{}{
-					"key":    key,
-					"value":  value,
-					"exists": true,
-				})
-				logrus.Debugf("Found pre-lock: %s = %s", key, value)
-			}
-		}
-		locks["pre_locks"] = preLocks
-		logrus.Debugf("Found %d pre-locks", len(preLocks))
-	} else {
-		locks["pre_locks"] = []map[string]interface{}{}
-		logrus.Debugf("Error searching for pre-locks: %v", err)
-	}
-
-	settingsKeys, err := scanKeys(ctx, redisClient, "bootstrap:settings:*")
-	if err == nil {
-		settings := make([]map[string]interface{}, 0)
-		for _, key := range settingsKeys {
-			value, err := redisClient.Get(ctx, key).Result()
-			if err == nil {
-				settings = append(settings, map[string]interface{}{
-					"key":    key,
-					"value":  value,
-					"exists": true,
-				})
-				logrus.Debugf("Found bootstrap setting: %s = %s", key, value)
-			}
-		}
-		locks["settings"] = settings
-		logrus.Debugf("Found %d bootstrap settings", len(settings))
-	} else {
-		locks["settings"] = []map[string]interface{}{}
-		logrus.Debugf("Error searching for bootstrap settings: %v", err)
-	}
-
-	c.JSON(http.StatusOK, gin.H{
-		"data":    locks,
-		"message": "Bootstrap locks status retrieved successfully",
-	})
-}
-
 func PostBootstrap(c *gin.Context, redisClient *redis.Client) {
 	adminName, err := utils.GetUsernameFromContext(c)
 	if err != nil {
@@ -323,6 +235,10 @@ func PostBootstrap(c *gin.Context, redisClient *redis.Client) {
 		})
 		return
 	}
+	if err := tuf_utils.ValidateAppName(payload.AppName); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
 
 	if redisClient == nil {
 		logrus.Errorf("Redis client is nil, refusing bootstrap for admin %s, app %s", adminName, payload.AppName)
@@ -332,83 +248,55 @@ func PostBootstrap(c *gin.Context, redisClient *redis.Client) {
 		return
 	}
 
-	if redisClient != nil {
-		ctx := context.Background()
-		bootstrapKey := "BOOTSTRAP_" + adminName + "_" + payload.AppName
-		bootstrapValue, err := redisClient.Get(ctx, bootstrapKey).Result()
-		logrus.Debugf("Bootstrap key: %s, value: %s", bootstrapKey, bootstrapValue)
-		if err == nil && bootstrapValue != "" {
-			// Check if temporary keys still exist (bootstrap is in progress)
-			preLockKey := bootstrapValue
-			settingsKey := "bootstrap:settings:" + bootstrapValue
+	ctx := context.Background()
+	bootstrapKey := "BOOTSTRAP_" + adminName + "_" + payload.AppName
+	bootstrapValue, err := redisClient.Get(ctx, bootstrapKey).Result()
+	logrus.Debugf("Bootstrap key: %s, value: %s", bootstrapKey, bootstrapValue)
+	if err == nil && bootstrapValue != "" {
+		// Check if temporary keys still exist (bootstrap is in progress)
+		preLockKey := bootstrapValue
+		settingsKey := "bootstrap:settings:" + bootstrapValue
 
-			preLockExists, err := redisClient.Exists(ctx, preLockKey).Result()
-			if err != nil {
-				logrus.Warnf("Error checking pre-lock key existence: %v", err)
-			}
+		preLockExists, err := redisClient.Exists(ctx, preLockKey).Result()
+		if err != nil {
+			logrus.Warnf("Error checking pre-lock key existence: %v", err)
+		}
 
-			settingsExists, err := redisClient.Exists(ctx, settingsKey).Result()
-			if err != nil {
-				logrus.Warnf("Error checking settings key existence: %v", err)
-			}
+		settingsExists, err := redisClient.Exists(ctx, settingsKey).Result()
+		if err != nil {
+			logrus.Warnf("Error checking settings key existence: %v", err)
+		}
 
-			if preLockExists > 0 || settingsExists > 0 {
-				logrus.Warnf("Bootstrap already in progress for admin %s, app %s. Task ID: %s", adminName, payload.AppName, bootstrapValue)
-				c.JSON(http.StatusConflict, gin.H{
-					"error": "Bootstrap already in progress for this admin and app",
-					"data": gin.H{
-						"task_id": bootstrapValue,
-						"admin":   adminName,
-						"app":     payload.AppName,
-						"status":  "in_progress",
-					},
-				})
-				return
-			}
+		if preLockExists > 0 || settingsExists > 0 {
+			logrus.Warnf("Bootstrap already in progress for admin %s, app %s. Task ID: %s", adminName, payload.AppName, bootstrapValue)
+			c.JSON(http.StatusConflict, gin.H{
+				"error": "Bootstrap already in progress for this admin and app",
+				"data": gin.H{
+					"task_id": bootstrapValue,
+					"admin":   adminName,
+					"app":     payload.AppName,
+					"status":  "in_progress",
+				},
+			})
+			return
+		}
 
-			if preLockExists == 0 && settingsExists == 0 {
+		if preLockExists == 0 && settingsExists == 0 {
 
-				if strings.HasPrefix(bootstrapValue, "pre-") {
-					taskIDFromValue := bootstrapValue[4:]
-					taskState := getTaskStatusFromRedis(redisClient, taskIDFromValue)
+			if strings.HasPrefix(bootstrapValue, "pre-") {
+				taskIDFromValue := bootstrapValue[4:]
+				taskState := getTaskStatusFromRedis(redisClient, taskIDFromValue)
 
-					// If task is in FAILURE, ERRORED, REVOKED state, or not found (PENDING but locks are gone),
-					// clean up the stale lock and allow new bootstrap
-					switch taskState {
-					case tasks.TaskStateFailure, tasks.TaskStateErrored, tasks.TaskStateRevoked, tasks.TaskStatePending:
-						logrus.Warnf("Found stale bootstrap lock from task %s (state: %s), cleaning up", taskIDFromValue, taskState)
-						releaseBootstrapLock(redisClient, taskIDFromValue, adminName, payload.AppName)
-						// Continue with bootstrap after cleanup
-					case tasks.TaskStateSuccess:
-						// Task succeeded but locks are missing - this shouldn't happen, but treat as completed
-						logrus.Warnf("Bootstrap task %s succeeded but locks are missing, treating as completed", taskIDFromValue)
-						c.JSON(http.StatusConflict, gin.H{
-							"error": "Bootstrap already completed for this admin and app",
-							"data": gin.H{
-								"task_id": bootstrapValue,
-								"admin":   adminName,
-								"app":     payload.AppName,
-								"status":  "completed",
-							},
-						})
-						return
-					default:
-						// Task is in progress (STARTED, RUNNING, etc.) but locks are missing - treat as in progress
-						logrus.Warnf("Bootstrap task %s is in state %s but locks are missing, treating as in progress", taskIDFromValue, taskState)
-						c.JSON(http.StatusConflict, gin.H{
-							"error": "Bootstrap already in progress for this admin and app",
-							"data": gin.H{
-								"task_id": taskIDFromValue,
-								"admin":   adminName,
-								"app":     payload.AppName,
-								"status":  "in_progress",
-							},
-						})
-						return
-					}
-				} else {
-					// bootstrapValue is a taskID (not pre-taskID), meaning bootstrap was completed
-					logrus.Warnf("Bootstrap already completed for admin %s, app %s. Task ID: %s", adminName, payload.AppName, bootstrapValue)
+				// If task is in FAILURE, ERRORED, REVOKED state, or not found (PENDING but locks are gone),
+				// clean up the stale lock and allow new bootstrap
+				switch taskState {
+				case tasks.TaskStateFailure, tasks.TaskStateErrored, tasks.TaskStateRevoked, tasks.TaskStatePending:
+					logrus.Warnf("Found stale bootstrap lock from task %s (state: %s), cleaning up", taskIDFromValue, taskState)
+					releaseBootstrapLock(redisClient, taskIDFromValue, adminName, payload.AppName)
+					// Continue with bootstrap after cleanup
+				case tasks.TaskStateSuccess:
+					// Task succeeded but locks are missing - this shouldn't happen, but treat as completed
+					logrus.Warnf("Bootstrap task %s succeeded but locks are missing, treating as completed", taskIDFromValue)
 					c.JSON(http.StatusConflict, gin.H{
 						"error": "Bootstrap already completed for this admin and app",
 						"data": gin.H{
@@ -419,40 +307,66 @@ func PostBootstrap(c *gin.Context, redisClient *redis.Client) {
 						},
 					})
 					return
+				default:
+					// Task is in progress (STARTED, RUNNING, etc.) but locks are missing - treat as in progress
+					logrus.Warnf("Bootstrap task %s is in state %s but locks are missing, treating as in progress", taskIDFromValue, taskState)
+					c.JSON(http.StatusConflict, gin.H{
+						"error": "Bootstrap already in progress for this admin and app",
+						"data": gin.H{
+							"task_id": taskIDFromValue,
+							"admin":   adminName,
+							"app":     payload.AppName,
+							"status":  "in_progress",
+						},
+					})
+					return
 				}
+			} else {
+				// bootstrapValue is a taskID (not pre-taskID), meaning bootstrap was completed
+				logrus.Warnf("Bootstrap already completed for admin %s, app %s. Task ID: %s", adminName, payload.AppName, bootstrapValue)
+				c.JSON(http.StatusConflict, gin.H{
+					"error": "Bootstrap already completed for this admin and app",
+					"data": gin.H{
+						"task_id": bootstrapValue,
+						"admin":   adminName,
+						"app":     payload.AppName,
+						"status":  "completed",
+					},
+				})
+				return
 			}
 		}
-
-		preLockKeys, err := scanKeys(ctx, redisClient, "pre-*")
-		if err == nil {
-			for _, preKey := range preLockKeys {
-
-				taskIDFromPre := preKey[4:] // Remove "pre-" prefix
-
-				settingsKey := "bootstrap:settings:" + taskIDFromPre
-				settingsExists, err := redisClient.Exists(ctx, settingsKey).Result()
-				if err == nil && settingsExists > 0 {
-
-					bootstrapKey := "BOOTSTRAP_" + adminName + "_" + payload.AppName
-					bootstrapValue, err := redisClient.Get(ctx, bootstrapKey).Result()
-					if err == nil && bootstrapValue == taskIDFromPre {
-						logrus.Warnf("Bootstrap already in progress for admin %s, app %s. Task ID: %s (found via pre-lock)", adminName, payload.AppName, taskIDFromPre)
-						c.JSON(http.StatusConflict, gin.H{
-							"error": "Bootstrap already in progress for this admin and app",
-							"data": gin.H{
-								"task_id": taskIDFromPre,
-								"admin":   adminName,
-								"app":     payload.AppName,
-								"status":  "in_progress",
-							},
-						})
-						return
-					}
-				}
-			}
-		}
-		logrus.Debugf("No existing bootstrap lock or in-progress bootstrap found for admin %s, app %s", adminName, payload.AppName)
 	}
+
+	preLockKeys, err := scanKeys(ctx, redisClient, "pre-*")
+	if err == nil {
+		for _, preKey := range preLockKeys {
+
+			taskIDFromPre := preKey[4:] // Remove "pre-" prefix
+
+			settingsKey := "bootstrap:settings:" + taskIDFromPre
+			settingsExists, err := redisClient.Exists(ctx, settingsKey).Result()
+			if err == nil && settingsExists > 0 {
+
+				bootstrapKey := "BOOTSTRAP_" + adminName + "_" + payload.AppName
+				bootstrapValue, err := redisClient.Get(ctx, bootstrapKey).Result()
+				if err == nil && bootstrapValue == taskIDFromPre {
+					logrus.Warnf("Bootstrap already in progress for admin %s, app %s. Task ID: %s (found via pre-lock)", adminName, payload.AppName, taskIDFromPre)
+					c.JSON(http.StatusConflict, gin.H{
+						"error": "Bootstrap already in progress for this admin and app",
+						"data": gin.H{
+							"task_id": taskIDFromPre,
+							"admin":   adminName,
+							"app":     payload.AppName,
+							"status":  "in_progress",
+						},
+					})
+					return
+				}
+			}
+		}
+	}
+	logrus.Debugf("No existing bootstrap lock or in-progress bootstrap found for admin %s, app %s", adminName, payload.AppName)
 
 	logrus.Debug("Checking bootstrap state using persistent metadata")
 	isInitialized, err := hasPersistedRootMetadata(context.Background(), adminName, payload.AppName)
@@ -600,16 +514,6 @@ func preLockBootstrap(
 	return true, ""
 }
 
-func bootstrap(
-	redisClient *redis.Client,
-	taskID string,
-	adminName string,
-	appName string,
-	payload *models.BootstrapPayload,
-) {
-	bootstrapWithContext(context.Background(), redisClient, taskID, adminName, appName, payload)
-}
-
 func bootstrapWithContext(
 	ctx context.Context,
 	redisClient *redis.Client,
@@ -667,16 +571,6 @@ func bootstrapWithContext(
 		logrus.Debugf("Cleaning up bootstrap locks after failure for admin: %s, task_id: %s", adminName, taskID)
 		releaseBootstrapLock(redisClient, taskID, adminName, appName)
 	}
-}
-
-func bootstrapFinalize(
-	redisClient *redis.Client,
-	taskID string,
-	adminName string,
-	appName string,
-	payload *models.BootstrapPayload,
-) bool {
-	return bootstrapFinalizeWithContext(context.Background(), redisClient, taskID, adminName, appName, payload)
 }
 
 func bootstrapFinalizeWithContext(

--- a/server/tuf/bootstrap/bootstrap_test.go
+++ b/server/tuf/bootstrap/bootstrap_test.go
@@ -3,13 +3,18 @@ package bootstrap
 import (
 	"bytes"
 	"context"
+	"crypto"
+	"crypto/ed25519"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"fmt"
 
 	"faynoSync/server/tuf/models"
 	tuf_storage "faynoSync/server/tuf/storage"
@@ -18,8 +23,12 @@ import (
 	"github.com/alicebob/miniredis/v2"
 	"github.com/gin-gonic/gin"
 	"github.com/go-redis/redis/v8"
+	"github.com/sigstore/sigstore/pkg/signature"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/theupdateframework/go-tuf/v2/examples/repository/repository"
+	gotufmetadata "github.com/theupdateframework/go-tuf/v2/metadata"
 )
 
 func TestMain(m *testing.M) {
@@ -684,7 +693,7 @@ func TestPreLockBootstrap_WithRedis_BootstrapKeyAlreadyExists_ReturnsNotAcquired
 // To verify: In bootstrap remove nil checks for redisClient in UpdateTaskState/saveSettings path; test may panic or behave differently.
 func TestBootstrap_NilRedis_NoPanic(t *testing.T) {
 	payload := validMinimalBootstrapPayload()
-	bootstrap(nil, "task-nil", "admin", "myapp", payload)
+	bootstrapWithContext(context.Background(), nil, "task-nil", "admin", "myapp", payload)
 }
 
 // To verify: In bootstrap change failure path to not call releaseBootstrapLock; test will fail (keys still present).
@@ -701,7 +710,7 @@ func TestBootstrap_FinalizeFails_ReleasesLock(t *testing.T) {
 	payload := validMinimalBootstrapPayload()
 	// Minimal payload causes BootstrapOnlineRoles to fail, so bootstrapFinalize returns false
 
-	bootstrap(client, taskID, adminName, appName, payload)
+	bootstrapWithContext(context.Background(), client, taskID, adminName, appName, payload)
 
 	// releaseBootstrapLock should have deleted pre-<taskID> and BOOTSTRAP_<admin>_<app>
 	_, err := client.Get(client.Context(), "pre-"+taskID).Result()
@@ -723,7 +732,7 @@ func TestBootstrap_FinalizeFails_SavesFailureState(t *testing.T) {
 	taskName := tasks.TaskNameBootstrap
 	tasks.SaveTaskStatus(client, taskID, tasks.TaskStatePending, &tasks.TaskResult{Task: &taskName})
 
-	bootstrap(client, taskID, adminName, appName, payload)
+	bootstrapWithContext(context.Background(), client, taskID, adminName, appName, payload)
 
 	taskData, err := client.Get(client.Context(), "task:"+taskID).Result()
 	require.NoError(t, err)
@@ -745,7 +754,7 @@ func TestBootstrap_WithRedis_UpdatesTaskStateThenSavesFailure(t *testing.T) {
 	appName := "a"
 	payload := validMinimalBootstrapPayload()
 
-	bootstrap(client, taskID, adminName, appName, payload)
+	bootstrapWithContext(context.Background(), client, taskID, adminName, appName, payload)
 
 	taskData, err := client.Get(client.Context(), "task:"+taskID).Result()
 	require.NoError(t, err)
@@ -760,7 +769,7 @@ func TestBootstrap_WithRedis_UpdatesTaskStateThenSavesFailure(t *testing.T) {
 // To verify: In bootstrapFinalize remove nil check for redisClient in the cleanup block; test still passes (we return false before that block).
 func TestBootstrapFinalize_NilRedis_ReturnsFalse(t *testing.T) {
 	payload := validMinimalBootstrapPayload()
-	got := bootstrapFinalize(nil, "task-nil", "admin", "myapp", payload)
+	got := bootstrapFinalizeWithContext(context.Background(), nil, "task-nil", "admin", "myapp", payload)
 	assert.False(t, got, "bootstrapFinalize should return false when BootstrapOnlineRoles fails (nil Redis)")
 }
 
@@ -771,7 +780,7 @@ func TestBootstrapFinalize_BootstrapOnlineRolesFails_ReturnsFalse(t *testing.T) 
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 	payload := validMinimalBootstrapPayload()
 
-	got := bootstrapFinalize(client, "task-fail", "admin", "myapp", payload)
+	got := bootstrapFinalizeWithContext(context.Background(), client, "task-fail", "admin", "myapp", payload)
 
 	assert.False(t, got, "bootstrapFinalize should return false when BootstrapOnlineRoles fails")
 }
@@ -790,7 +799,7 @@ func TestBootstrapFinalize_BootstrapOnlineRolesFails_DoesNotModifyRedis(t *testi
 	mr.Set(bootstrapKey, originalValue)
 	payload := validMinimalBootstrapPayload()
 
-	bootstrapFinalize(client, taskID, adminName, appName, payload)
+	bootstrapFinalizeWithContext(context.Background(), client, taskID, adminName, appName, payload)
 
 	val, err := client.Get(client.Context(), bootstrapKey).Result()
 	require.NoError(t, err)
@@ -1262,4 +1271,177 @@ func TestRunBootstrapRecovery_AbortsWhenBootstrapMarkerChanged(t *testing.T) {
 	require.NotNil(t, taskStatus.Result)
 	require.NotNil(t, taskStatus.Result.Error)
 	assert.Contains(t, *taskStatus.Result.Error, "bootstrap marker changed")
+}
+
+// --- H-2 regression: recoverSettingsFromStorage derives TargetsOnlineKey from ONLINE_KEY_DIR ---
+
+// makeRecoveryTUFRepo creates a minimal signed TUF repository and returns
+// the serialised metadata bytes for each role plus the targets keyID.
+func makeRecoveryTUFRepo(t *testing.T) (root, targets, snap, ts []byte, targetsKeyID string) {
+	t.Helper()
+	expires := time.Now().Add(365 * 24 * time.Hour)
+	roles := repository.New()
+	roles.SetRoot(gotufmetadata.Root(expires))
+	roles.SetTargets("targets", gotufmetadata.Targets(expires))
+	roles.SetSnapshot(gotufmetadata.Snapshot(expires))
+	roles.SetTimestamp(gotufmetadata.Timestamp(expires))
+
+	keys := map[string]ed25519.PrivateKey{}
+	for _, name := range []string{"root", "targets", "snapshot", "timestamp"} {
+		_, priv, err := ed25519.GenerateKey(nil)
+		require.NoError(t, err)
+		keys[name] = priv
+		k, err := gotufmetadata.KeyFromPublicKey(priv.Public())
+		require.NoError(t, err)
+		require.NoError(t, roles.Root().Signed.AddKey(k, name))
+		if name == "targets" {
+			targetsKeyID, err = k.ID()
+			require.NoError(t, err)
+		}
+	}
+	for _, name := range []string{"root", "targets", "snapshot", "timestamp"} {
+		s, err := signature.LoadSigner(keys[name], crypto.Hash(0))
+		require.NoError(t, err)
+		switch name {
+		case "root":
+			_, err = roles.Root().Sign(s)
+		case "targets":
+			_, err = roles.Targets("targets").Sign(s)
+		case "snapshot":
+			_, err = roles.Snapshot().Sign(s)
+		case "timestamp":
+			_, err = roles.Timestamp().Sign(s)
+		}
+		require.NoError(t, err)
+	}
+	snap_meta := map[string]*gotufmetadata.MetaFiles{
+		"targets.json": gotufmetadata.MetaFile(int64(roles.Targets("targets").Signed.Version)),
+	}
+	roles.Snapshot().Signed.Meta = snap_meta
+	ts_meta := map[string]*gotufmetadata.MetaFiles{
+		"snapshot.json": gotufmetadata.MetaFile(int64(roles.Snapshot().Signed.Version)),
+	}
+	roles.Timestamp().Signed.Meta = ts_meta
+
+	dir := t.TempDir()
+	write := func(name string, obj interface{ ToFile(string, bool) error }) []byte {
+		p := filepath.Join(dir, name)
+		require.NoError(t, obj.ToFile(p, true))
+		b, err := os.ReadFile(p)
+		require.NoError(t, err)
+		return b
+	}
+	root = write("1.root.json", roles.Root())
+	targets = write("1.targets.json", roles.Targets("targets"))
+	snap = write("1.snapshot.json", roles.Snapshot())
+	ts = write("timestamp.json", roles.Timestamp())
+	return
+}
+
+// To verify: (remove ONLINE_KEY_DIR check); test will fail (TargetsOnlineKey=true when it should be false).
+func TestRecoverSettingsFromStorage_OfflineTargets_TargetsOnlineKeyFalse(t *testing.T) {
+	rootBytes, targetsBytes, snapBytes, tsBytes, _ := makeRecoveryTUFRepo(t)
+
+	objects := map[string][]byte{
+		"tuf_metadata/admin/myapp/1.root.json":     rootBytes,
+		"tuf_metadata/admin/myapp/1.targets.json":  targetsBytes,
+		"tuf_metadata/admin/myapp/1.snapshot.json": snapBytes,
+		"tuf_metadata/admin/myapp/timestamp.json":  tsBytes,
+	}
+
+	savedFind := findLatestMetadataBootstrap
+	savedDownload := downloadMetadataForBootstrap
+	findLatestMetadataBootstrap = func(_ context.Context, _, _, roleName string) (int, string, error) {
+		switch roleName {
+		case "root":
+			return 1, "1.root.json", nil
+		case "targets":
+			return 1, "1.targets.json", nil
+		case "snapshot":
+			return 1, "1.snapshot.json", nil
+		}
+		return 0, "", fmt.Errorf("not found: %s", roleName)
+	}
+	downloadMetadataForBootstrap = func(_ context.Context, _, _, objectKey, filePath string) error {
+		data, ok := objects[objectKey]
+		if !ok {
+			// Try last path segment
+			for k, v := range objects {
+				if filepath.Base(k) == filepath.Base(objectKey) {
+					return os.WriteFile(filePath, v, 0644)
+				}
+			}
+			return fmt.Errorf("object not found: %s", objectKey)
+		}
+		return os.WriteFile(filePath, data, 0644)
+	}
+	defer func() {
+		findLatestMetadataBootstrap = savedFind
+		downloadMetadataForBootstrap = savedDownload
+	}()
+
+	// ONLINE_KEY_DIR is empty — targets key file is absent.
+	emptyKeyDir := t.TempDir()
+	oldDir := viper.GetString("ONLINE_KEY_DIR")
+	viper.Set("ONLINE_KEY_DIR", emptyKeyDir)
+	defer viper.Set("ONLINE_KEY_DIR", oldDir)
+
+	settings, err := recoverSettingsFromStorage(context.Background(), "admin", "myapp")
+
+	require.NoError(t, err)
+	assert.False(t, settings.TargetsOnlineKey, "targets must be offline when key is absent from ONLINE_KEY_DIR")
+}
+
+// To verify: (TargetsOnlineKey=false when it should be true).
+func TestRecoverSettingsFromStorage_OnlineTargets_TargetsOnlineKeyTrue(t *testing.T) {
+	rootBytes, targetsBytes, snapBytes, tsBytes, targetsKeyID := makeRecoveryTUFRepo(t)
+
+	objects := map[string][]byte{
+		"tuf_metadata/admin/myapp/1.root.json":     rootBytes,
+		"tuf_metadata/admin/myapp/1.targets.json":  targetsBytes,
+		"tuf_metadata/admin/myapp/1.snapshot.json": snapBytes,
+		"tuf_metadata/admin/myapp/timestamp.json":  tsBytes,
+	}
+
+	savedFind := findLatestMetadataBootstrap
+	savedDownload := downloadMetadataForBootstrap
+	findLatestMetadataBootstrap = func(_ context.Context, _, _, roleName string) (int, string, error) {
+		switch roleName {
+		case "root":
+			return 1, "1.root.json", nil
+		case "targets":
+			return 1, "1.targets.json", nil
+		case "snapshot":
+			return 1, "1.snapshot.json", nil
+		}
+		return 0, "", fmt.Errorf("not found: %s", roleName)
+	}
+	downloadMetadataForBootstrap = func(_ context.Context, _, _, objectKey, filePath string) error {
+		data, ok := objects[objectKey]
+		if !ok {
+			for k, v := range objects {
+				if filepath.Base(k) == filepath.Base(objectKey) {
+					return os.WriteFile(filePath, v, 0644)
+				}
+			}
+			return fmt.Errorf("object not found: %s", objectKey)
+		}
+		return os.WriteFile(filePath, data, 0644)
+	}
+	defer func() {
+		findLatestMetadataBootstrap = savedFind
+		downloadMetadataForBootstrap = savedDownload
+	}()
+
+	// ONLINE_KEY_DIR contains a file named after the targets keyID — targets is online.
+	keyDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(keyDir, targetsKeyID), []byte("dummy"), 0600))
+	oldDir := viper.GetString("ONLINE_KEY_DIR")
+	viper.Set("ONLINE_KEY_DIR", keyDir)
+	defer viper.Set("ONLINE_KEY_DIR", oldDir)
+
+	settings, err := recoverSettingsFromStorage(context.Background(), "admin", "myapp")
+
+	require.NoError(t, err)
+	assert.True(t, settings.TargetsOnlineKey, "targets must be online when key file is present in ONLINE_KEY_DIR")
 }

--- a/server/tuf/bootstrap/recovery.go
+++ b/server/tuf/bootstrap/recovery.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"faynoSync/server/tuf/models"
 	"faynoSync/server/tuf/tasks"
+	tuf_utils "faynoSync/server/tuf/utils"
 	"faynoSync/server/utils"
 	"fmt"
 	"math"
@@ -19,6 +20,7 @@ import (
 	"github.com/go-redis/redis/v8"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
 	"github.com/theupdateframework/go-tuf/v2/examples/repository/repository"
 	gotufmetadata "github.com/theupdateframework/go-tuf/v2/metadata"
 )
@@ -102,6 +104,10 @@ func PostBootstrapRecovery(c *gin.Context, redisClient *redis.Client) {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error": "Missing required field: appName",
 		})
+		return
+	}
+	if valErr := tuf_utils.ValidateAppName(payload.AppName); valErr != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": valErr.Error()})
 		return
 	}
 
@@ -439,11 +445,7 @@ func isRecoveryRequired(ctx context.Context, redisClient *redis.Client, adminNam
 }
 
 func recoverSettingsFromStorage(ctx context.Context, adminName, appName string) (recoveredBootstrapSettings, error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return recoveredBootstrapSettings{}, fmt.Errorf("failed to get current working directory: %w", err)
-	}
-	tmpDir, err := os.MkdirTemp(cwd, "tmp-recovery-*")
+	tmpDir, err := os.MkdirTemp("", "tmp-recovery-*")
 	if err != nil {
 		return recoveredBootstrapSettings{}, fmt.Errorf("failed to create temporary directory: %w", err)
 	}
@@ -602,6 +604,18 @@ func recoverSettingsFromStorage(ctx context.Context, adminName, appName string) 
 		delegatedExpiration[roleName] = days
 	}
 
+	targetsOnlineKey := false
+	if onlineKeyDir := viper.GetString("ONLINE_KEY_DIR"); onlineKeyDir != "" {
+		if targetsRole, ok := rootMetadata.Signed.Roles["targets"]; ok {
+			for _, keyID := range targetsRole.KeyIDs {
+				if _, statErr := os.Stat(filepath.Join(onlineKeyDir, keyID)); statErr == nil {
+					targetsOnlineKey = true
+					break
+				}
+			}
+		}
+	}
+
 	return recoveredBootstrapSettings{
 		RootExpiration:      rootExpirationDays,
 		RootThreshold:       roleThreshold("root"),
@@ -615,7 +629,7 @@ func recoverSettingsFromStorage(ctx context.Context, adminName, appName string) 
 		TimestampExpiration: timestampExpirationDays,
 		TimestampThreshold:  roleThreshold("timestamp"),
 		TimestampNumKeys:    roleNumKeys("timestamp"),
-		TargetsOnlineKey:    true,
+		TargetsOnlineKey:    targetsOnlineKey,
 		DelegatedExpiration: delegatedExpiration,
 	}, nil
 }

--- a/server/tuf/config/config.go
+++ b/server/tuf/config/config.go
@@ -10,6 +10,7 @@ import (
 
 	"faynoSync/server/tuf/models"
 	"faynoSync/server/tuf/tasks"
+	tuf_utils "faynoSync/server/tuf/utils"
 	"faynoSync/server/utils"
 
 	"github.com/gin-gonic/gin"
@@ -31,6 +32,10 @@ func GetConfig(c *gin.Context, redisClient *redis.Client) {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error": "appName query parameter is required",
 		})
+		return
+	}
+	if err := tuf_utils.ValidateAppName(appName); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
@@ -110,7 +115,6 @@ func GetConfig(c *gin.Context, redisClient *redis.Client) {
 		}
 
 		for _, fullKey := range keys {
-
 			alreadyProcessed := false
 			for _, standardKey := range settingsKeys {
 				if standardKey != "BOOTSTRAP" && fullKey == standardKey+"_"+keySuffix {
@@ -122,22 +126,17 @@ func GetConfig(c *gin.Context, redisClient *redis.Client) {
 				continue
 			}
 
-			keyWithoutSuffix := strings.TrimSuffix(fullKey, "_EXPIRATION_"+keySuffix)
-			if keyWithoutSuffix == fullKey {
+			roleName := strings.TrimSuffix(fullKey, "_EXPIRATION_"+keySuffix)
+			if roleName == fullKey {
 				continue
 			}
 
 			value, err := redisClient.Get(ctx, fullKey).Result()
 			if err == nil && value != "" {
 				if intVal, err := strconv.Atoi(value); err == nil {
-					settings["role_expiration"] = intVal
-					break
+					settings[strings.ToLower(roleName)+"_expiration"] = intVal
 				}
 			}
-		}
-
-		if _, found := settings["role_expiration"]; found {
-			break
 		}
 
 		if cursor == 0 {
@@ -164,6 +163,10 @@ func PutConfig(c *gin.Context, redisClient *redis.Client) {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error": "appName query parameter is required",
 		})
+		return
+	}
+	if err := tuf_utils.ValidateAppName(appName); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
@@ -201,6 +204,11 @@ func PutConfig(c *gin.Context, redisClient *redis.Client) {
 		"snapshot":  true,
 		"timestamp": true,
 		// "bins":      true,
+	}
+
+	targetsOnlineVal, _ := redisClient.Get(ctx, "TARGETS_ONLINE_KEY_"+keySuffix).Result()
+	if targetsOnlineVal != "true" && targetsOnlineVal != "1" {
+		delete(validOnlineRoles, "targets")
 	}
 
 	updatedRoles := []string{}

--- a/server/tuf/config/config_test.go
+++ b/server/tuf/config/config_test.go
@@ -168,22 +168,23 @@ func TestGetConfig_Success_WithStringSettings_PreservesString(t *testing.T) {
 	assert.Equal(t, "five", resp.Data["number_of_delegated_bins"])
 }
 
-// To verify: In GetConfig change Scan pattern or role_expiration assignment; test will fail (missing role_expiration).
+// To verify: In GetConfig change Scan pattern or expiration key derivation; test will fail (missing key).
 func TestGetConfig_Success_WithCustomRoleExpiration_IncludesRoleExpiration(t *testing.T) {
 	c, w := makeGetConfigContext("appName", "owner")
 	mr := miniredis.RunT(t)
 	defer mr.Close()
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 	mr.Set("BOOTSTRAP_owner_appName", "done")
-
 	mr.Set("DELEGATED_EXPIRATION_owner_appName", "30")
+	mr.Set("OTHERROLE_EXPIRATION_owner_appName", "60")
 
 	GetConfig(c, client)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	var resp models.GetConfigResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	assert.Equal(t, float64(30), resp.Data["role_expiration"])
+	assert.Equal(t, float64(30), resp.Data["delegated_expiration"])
+	assert.Equal(t, float64(60), resp.Data["otherrole_expiration"])
 }
 
 // To verify: In GetConfig change the bootstrap Get error handling to return 200 on Redis error; test will fail (wrong status).
@@ -328,6 +329,7 @@ func TestPutConfig_Success_ValidRole_UpdatesRedisAndReturns202(t *testing.T) {
 	defer mr.Close()
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 	mr.Set("BOOTSTRAP_owner_appName", "done")
+	mr.Set("TARGETS_ONLINE_KEY_owner_appName", "true")
 	mr.Set("TARGETS_EXPIRATION_owner_appName", "90") // existing value
 
 	PutConfig(c, client)
@@ -468,6 +470,7 @@ func TestPutConfig_PartialSuccess_SomeValidSomeInvalid(t *testing.T) {
 	defer mr.Close()
 	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 	mr.Set("BOOTSTRAP_owner_appName", "done")
+	mr.Set("TARGETS_ONLINE_KEY_owner_appName", "true")
 	mr.Set("TARGETS_EXPIRATION_owner_appName", "90")
 	mr.Set("SNAPSHOT_EXPIRATION_owner_appName", "60")
 

--- a/server/tuf/delegations/delegation.go
+++ b/server/tuf/delegations/delegation.go
@@ -1,7 +1,6 @@
 package delegations
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -11,7 +10,6 @@ import (
 )
 
 func UpdateDelegationPaths(
-	ctx context.Context,
 	repo *repository.Type,
 	roleName string,
 	artifactPaths []string,
@@ -97,7 +95,6 @@ func UpdateDelegationPaths(
 }
 
 func RemoveDelegationPaths(
-	ctx context.Context,
 	repo *repository.Type,
 	roleName string,
 	artifactPaths []string,

--- a/server/tuf/delegations/delegation_test.go
+++ b/server/tuf/delegations/delegation_test.go
@@ -1,7 +1,6 @@
 package delegations
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -70,10 +69,9 @@ func pathSliceContains(paths []string, p string) bool {
 
 // To verify: In UpdateDelegationPaths change the condition so repo.Targets("targets") nil is not treated as error; test will fail (no error or wrong message).
 func TestUpdateDelegationPaths_TargetsNotLoaded(t *testing.T) {
-	ctx := context.Background()
 	repo := repoWithNoTargets()
 
-	updated, err := UpdateDelegationPaths(ctx, repo, "myrole", []string{"a/b"}, "admin")
+	updated, err := UpdateDelegationPaths(repo, "myrole", []string{"a/b"}, "admin")
 
 	require.Error(t, err)
 	assert.False(t, updated)
@@ -82,10 +80,9 @@ func TestUpdateDelegationPaths_TargetsNotLoaded(t *testing.T) {
 
 // To verify: In UpdateDelegationPaths skip the check for delegations == nil; test will fail (panic or wrong error).
 func TestUpdateDelegationPaths_NoDelegations(t *testing.T) {
-	ctx := context.Background()
 	repo := repoWithTargetsNoDelegations()
 
-	updated, err := UpdateDelegationPaths(ctx, repo, "myrole", []string{"a/b"}, "admin")
+	updated, err := UpdateDelegationPaths(repo, "myrole", []string{"a/b"}, "admin")
 
 	require.Error(t, err)
 	assert.False(t, updated)
@@ -94,10 +91,9 @@ func TestUpdateDelegationPaths_NoDelegations(t *testing.T) {
 
 // To verify: In UpdateDelegationPaths skip the check for delegations.Roles == nil; test will fail (panic or wrong error).
 func TestUpdateDelegationPaths_DelegationsRolesNil(t *testing.T) {
-	ctx := context.Background()
 	repo := repoWithTargetsDelegationsRolesNil()
 
-	updated, err := UpdateDelegationPaths(ctx, repo, "myrole", []string{"a/b"}, "admin")
+	updated, err := UpdateDelegationPaths(repo, "myrole", []string{"a/b"}, "admin")
 
 	require.Error(t, err)
 	assert.False(t, updated)
@@ -106,10 +102,9 @@ func TestUpdateDelegationPaths_DelegationsRolesNil(t *testing.T) {
 
 // To verify: In UpdateDelegationPaths change role lookup so a wrong name is accepted; test will fail (no error or wrong message).
 func TestUpdateDelegationPaths_RoleNotFound(t *testing.T) {
-	ctx := context.Background()
 	repo := repoWithTargetsAndDelegations("existing-role", []string{"x"})
 
-	updated, err := UpdateDelegationPaths(ctx, repo, "nonexistent", []string{"a/b"}, "admin")
+	updated, err := UpdateDelegationPaths(repo, "nonexistent", []string{"a/b"}, "admin")
 
 	require.Error(t, err)
 	assert.False(t, updated)
@@ -118,12 +113,11 @@ func TestUpdateDelegationPaths_RoleNotFound(t *testing.T) {
 
 // To verify: In UpdateDelegationPaths change exact match logic so existing path is treated as new; test will fail (updated true or path duplicated).
 func TestUpdateDelegationPaths_AllPathsExactMatch_ReturnsFalseNoChange(t *testing.T) {
-	ctx := context.Background()
 	roleName := "myrole"
 	existingPath := "foo/bar"
 	repo := repoWithTargetsAndDelegations(roleName, []string{existingPath})
 
-	updated, err := UpdateDelegationPaths(ctx, repo, roleName, []string{existingPath}, "admin")
+	updated, err := UpdateDelegationPaths(repo, roleName, []string{existingPath}, "admin")
 
 	require.NoError(t, err)
 	assert.False(t, updated, "should not report update when all paths already exist (exact match)")
@@ -134,13 +128,12 @@ func TestUpdateDelegationPaths_AllPathsExactMatch_ReturnsFalseNoChange(t *testin
 
 // To verify: In UpdateDelegationPaths skip adding new path when !exactMatch; test will fail (updated false or path missing).
 func TestUpdateDelegationPaths_AddNewPath_ReturnsTrueAndPathAdded(t *testing.T) {
-	ctx := context.Background()
 	roleName := "myrole"
 	existingPath := "a"
 	newPath := "b"
 	repo := repoWithTargetsAndDelegations(roleName, []string{existingPath})
 
-	updated, err := UpdateDelegationPaths(ctx, repo, roleName, []string{newPath}, "admin")
+	updated, err := UpdateDelegationPaths(repo, roleName, []string{newPath}, "admin")
 
 	require.NoError(t, err)
 	assert.True(t, updated)
@@ -151,11 +144,10 @@ func TestUpdateDelegationPaths_AddNewPath_ReturnsTrueAndPathAdded(t *testing.T) 
 
 // To verify: In UpdateDelegationPaths do not add full path when artifactPath has prefix match; test will fail (path "foo/bar" missing).
 func TestUpdateDelegationPaths_PrefixMatch_AddsFullPath(t *testing.T) {
-	ctx := context.Background()
 	roleName := "myrole"
 	repo := repoWithTargetsAndDelegations(roleName, []string{"foo/"})
 
-	updated, err := UpdateDelegationPaths(ctx, repo, roleName, []string{"foo/bar"}, "admin")
+	updated, err := UpdateDelegationPaths(repo, roleName, []string{"foo/bar"}, "admin")
 
 	require.NoError(t, err)
 	assert.True(t, updated)
@@ -165,11 +157,10 @@ func TestUpdateDelegationPaths_PrefixMatch_AddsFullPath(t *testing.T) {
 
 // To verify: In UpdateDelegationPaths change behavior for empty artifactPaths (e.g. return error); test will fail (wrong return).
 func TestUpdateDelegationPaths_EmptyArtifactPaths_ReturnsFalseNoError(t *testing.T) {
-	ctx := context.Background()
 	roleName := "myrole"
 	repo := repoWithTargetsAndDelegations(roleName, []string{"a"})
 
-	updated, err := UpdateDelegationPaths(ctx, repo, roleName, []string{}, "admin")
+	updated, err := UpdateDelegationPaths(repo, roleName, []string{}, "admin")
 
 	require.NoError(t, err)
 	assert.False(t, updated)
@@ -180,12 +171,11 @@ func TestUpdateDelegationPaths_EmptyArtifactPaths_ReturnsFalseNoError(t *testing
 
 // To verify: In UpdateDelegationPaths add duplicate paths to role; test will fail (duplicate in Paths).
 func TestUpdateDelegationPaths_DuplicateInInput_AddedOnce(t *testing.T) {
-	ctx := context.Background()
 	roleName := "myrole"
 	newPath := "only-one"
 	repo := repoWithTargetsAndDelegations(roleName, []string{})
 
-	updated, err := UpdateDelegationPaths(ctx, repo, roleName, []string{newPath, newPath}, "admin")
+	updated, err := UpdateDelegationPaths(repo, roleName, []string{newPath, newPath}, "admin")
 
 	require.NoError(t, err)
 	assert.True(t, updated)
@@ -201,12 +191,11 @@ func TestUpdateDelegationPaths_DuplicateInInput_AddedOnce(t *testing.T) {
 
 // To verify: In UpdateDelegationPaths change logic so repo is not updated via SetTargets; test will fail (paths not updated in repo).
 func TestUpdateDelegationPaths_MultipleNewPaths_AllAddedAndRepoUpdated(t *testing.T) {
-	ctx := context.Background()
 	roleName := "myrole"
 	repo := repoWithTargetsAndDelegations(roleName, []string{"existing"})
 	newPaths := []string{"p1", "p2", "p3"}
 
-	updated, err := UpdateDelegationPaths(ctx, repo, roleName, newPaths, "admin")
+	updated, err := UpdateDelegationPaths(repo, roleName, newPaths, "admin")
 
 	require.NoError(t, err)
 	assert.True(t, updated)
@@ -221,10 +210,9 @@ func TestUpdateDelegationPaths_MultipleNewPaths_AllAddedAndRepoUpdated(t *testin
 
 // To verify: In RemoveDelegationPaths skip the check for targets == nil; test will fail (panic or wrong error).
 func TestRemoveDelegationPaths_TargetsNotLoaded(t *testing.T) {
-	ctx := context.Background()
 	repo := repoWithNoTargets()
 
-	removed, err := RemoveDelegationPaths(ctx, repo, "myrole", []string{"a/b"}, "admin")
+	removed, err := RemoveDelegationPaths(repo, "myrole", []string{"a/b"}, "admin")
 
 	require.Error(t, err)
 	assert.False(t, removed)
@@ -233,10 +221,9 @@ func TestRemoveDelegationPaths_TargetsNotLoaded(t *testing.T) {
 
 // To verify: In RemoveDelegationPaths skip the check for delegations == nil; test will fail (panic or wrong error).
 func TestRemoveDelegationPaths_NoDelegations(t *testing.T) {
-	ctx := context.Background()
 	repo := repoWithTargetsNoDelegations()
 
-	removed, err := RemoveDelegationPaths(ctx, repo, "myrole", []string{"a/b"}, "admin")
+	removed, err := RemoveDelegationPaths(repo, "myrole", []string{"a/b"}, "admin")
 
 	require.Error(t, err)
 	assert.False(t, removed)
@@ -245,10 +232,9 @@ func TestRemoveDelegationPaths_NoDelegations(t *testing.T) {
 
 // To verify: In RemoveDelegationPaths skip the check for delegations.Roles == nil; test will fail (panic or wrong error).
 func TestRemoveDelegationPaths_DelegationsRolesNil(t *testing.T) {
-	ctx := context.Background()
 	repo := repoWithTargetsDelegationsRolesNil()
 
-	removed, err := RemoveDelegationPaths(ctx, repo, "myrole", []string{"a/b"}, "admin")
+	removed, err := RemoveDelegationPaths(repo, "myrole", []string{"a/b"}, "admin")
 
 	require.Error(t, err)
 	assert.False(t, removed)
@@ -257,10 +243,9 @@ func TestRemoveDelegationPaths_DelegationsRolesNil(t *testing.T) {
 
 // To verify: In RemoveDelegationPaths change role lookup so a wrong name is accepted; test will fail (no error or wrong message).
 func TestRemoveDelegationPaths_RoleNotFound(t *testing.T) {
-	ctx := context.Background()
 	repo := repoWithTargetsAndDelegations("existing-role", []string{"x"})
 
-	removed, err := RemoveDelegationPaths(ctx, repo, "nonexistent", []string{"a/b"}, "admin")
+	removed, err := RemoveDelegationPaths(repo, "nonexistent", []string{"a/b"}, "admin")
 
 	require.Error(t, err)
 	assert.False(t, removed)
@@ -269,11 +254,10 @@ func TestRemoveDelegationPaths_RoleNotFound(t *testing.T) {
 
 // To verify: In RemoveDelegationPaths skip exact path removal or SetTargets; test will fail (removed false or path still present).
 func TestRemoveDelegationPaths_RemoveExactPath_ReturnsTrueAndPathRemoved(t *testing.T) {
-	ctx := context.Background()
 	roleName := "myrole"
 	repo := repoWithTargetsAndDelegations(roleName, []string{"a", "b"})
 
-	removed, err := RemoveDelegationPaths(ctx, repo, roleName, []string{"a"}, "admin")
+	removed, err := RemoveDelegationPaths(repo, roleName, []string{"a"}, "admin")
 
 	require.NoError(t, err)
 	assert.True(t, removed)
@@ -284,11 +268,10 @@ func TestRemoveDelegationPaths_RemoveExactPath_ReturnsTrueAndPathRemoved(t *test
 
 // To verify: In RemoveDelegationPaths remove non-existent path (e.g. return true); test will fail (removed true or paths changed).
 func TestRemoveDelegationPaths_RemoveNonExistentPath_ReturnsFalse(t *testing.T) {
-	ctx := context.Background()
 	roleName := "myrole"
 	repo := repoWithTargetsAndDelegations(roleName, []string{"a"})
 
-	removed, err := RemoveDelegationPaths(ctx, repo, roleName, []string{"b"}, "admin")
+	removed, err := RemoveDelegationPaths(repo, roleName, []string{"b"}, "admin")
 
 	require.NoError(t, err)
 	assert.False(t, removed)
@@ -299,11 +282,10 @@ func TestRemoveDelegationPaths_RemoveNonExistentPath_ReturnsFalse(t *testing.T) 
 
 // To verify: In RemoveDelegationPaths change behavior for empty artifactPaths (e.g. return true); test will fail (wrong return).
 func TestRemoveDelegationPaths_EmptyArtifactPaths_ReturnsFalse(t *testing.T) {
-	ctx := context.Background()
 	roleName := "myrole"
 	repo := repoWithTargetsAndDelegations(roleName, []string{"a", "b"})
 
-	removed, err := RemoveDelegationPaths(ctx, repo, roleName, []string{}, "admin")
+	removed, err := RemoveDelegationPaths(repo, roleName, []string{}, "admin")
 
 	require.NoError(t, err)
 	assert.False(t, removed)
@@ -315,11 +297,10 @@ func TestRemoveDelegationPaths_EmptyArtifactPaths_ReturnsFalse(t *testing.T) {
 
 // To verify: In RemoveDelegationPaths remove only one occurrence per path or skip SetTargets; test will fail (wrong paths).
 func TestRemoveDelegationPaths_RemoveMultiplePaths_ReturnsTrueAndRepoUpdated(t *testing.T) {
-	ctx := context.Background()
 	roleName := "myrole"
 	repo := repoWithTargetsAndDelegations(roleName, []string{"a", "b", "c"})
 
-	removed, err := RemoveDelegationPaths(ctx, repo, roleName, []string{"a", "c"}, "admin")
+	removed, err := RemoveDelegationPaths(repo, roleName, []string{"a", "c"}, "admin")
 
 	require.NoError(t, err)
 	assert.True(t, removed)
@@ -330,11 +311,10 @@ func TestRemoveDelegationPaths_RemoveMultiplePaths_ReturnsTrueAndRepoUpdated(t *
 
 // To verify: In RemoveDelegationPaths do not remove path when only prefix matches; test will fail (path "foo" removed).
 func TestRemoveDelegationPaths_OnlyExactMatchRemoved_PrefixNotRemoved(t *testing.T) {
-	ctx := context.Background()
 	roleName := "myrole"
 	repo := repoWithTargetsAndDelegations(roleName, []string{"foo", "foo/bar"})
 
-	removed, err := RemoveDelegationPaths(ctx, repo, roleName, []string{"foo/bar"}, "admin")
+	removed, err := RemoveDelegationPaths(repo, roleName, []string{"foo/bar"}, "admin")
 
 	require.NoError(t, err)
 	assert.True(t, removed)
@@ -345,11 +325,10 @@ func TestRemoveDelegationPaths_OnlyExactMatchRemoved_PrefixNotRemoved(t *testing
 
 // To verify: In RemoveDelegationPaths change iteration order (e.g. forward) so slice removal is wrong; test may fail (wrong remaining paths).
 func TestRemoveDelegationPaths_RemoveFromMiddle_AllRemovedCorrectly(t *testing.T) {
-	ctx := context.Background()
 	roleName := "myrole"
 	repo := repoWithTargetsAndDelegations(roleName, []string{"first", "middle", "last"})
 
-	removed, err := RemoveDelegationPaths(ctx, repo, roleName, []string{"middle"}, "admin")
+	removed, err := RemoveDelegationPaths(repo, roleName, []string{"middle"}, "admin")
 
 	require.NoError(t, err)
 	assert.True(t, removed)

--- a/server/tuf/metadata/metadata.go
+++ b/server/tuf/metadata/metadata.go
@@ -1301,7 +1301,27 @@ func PostMetadataSign(c *gin.Context, redisClient *redis.Client) {
 			if int64(repo.Targets(payload.Role).Signed.Version) <= trustedRoleVersion {
 				validationError = fmt.Errorf("version must be greater than trusted version %d", trustedRoleVersion)
 				thresholdReached = false
-			} else if err := trustedRepo.Targets("targets").VerifyDelegate(payload.Role, repo.Targets(payload.Role)); err != nil {
+				break
+			}
+
+			trustedRootMeta, loadErr := loadTrustedRootMetadataFromS3(ctx, adminName, appName)
+			if loadErr != nil {
+				validationError = fmt.Errorf("failed to load trusted root metadata: %w", loadErr)
+				thresholdReached = false
+				break
+			}
+			if !trustedRepo.Targets("targets").Signed.Expires.After(time.Now().UTC()) {
+				validationError = fmt.Errorf("trusted targets metadata is expired at %s", trustedRepo.Targets("targets").Signed.Expires.UTC().Format(time.RFC3339))
+				thresholdReached = false
+				break
+			}
+			if err := trustedRootMeta.VerifyDelegate("targets", trustedRepo.Targets("targets")); err != nil {
+				validationError = fmt.Errorf("trusted targets metadata signature verification failed: %w", err)
+				thresholdReached = false
+				break
+			}
+
+			if err := trustedRepo.Targets("targets").VerifyDelegate(payload.Role, repo.Targets(payload.Role)); err != nil {
 				validationError = err
 				thresholdReached = false
 			} else {

--- a/server/tuf/metadata/metadata.go
+++ b/server/tuf/metadata/metadata.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"faynoSync/server/tuf/models"
 	"faynoSync/server/tuf/signing"
 	tuf_storage "faynoSync/server/tuf/storage"
@@ -48,12 +49,7 @@ func BootstrapOnlineRolesWithContext(
 	logrus.Debugf("Starting bootstrap online roles creation for admin: %s, app: %s", adminName, appName)
 
 	// Create temporary directory for storing metadata
-	cwd, err := os.Getwd()
-	if err != nil {
-		logrus.Errorf("Failed to get current working directory: %v", err)
-		return fmt.Errorf("failed to get current working directory: %w", err)
-	}
-	tmpDir, err := os.MkdirTemp(cwd, "tmp")
+	tmpDir, err := os.MkdirTemp("", "tmp")
 	if err != nil {
 		logrus.Errorf("Failed to create temporary directory: %v", err)
 		return fmt.Errorf("failed to create temporary directory: %w", err)
@@ -176,9 +172,6 @@ func BootstrapOnlineRolesWithContext(
 	timestamp := metadata.Timestamp(tuf_utils.HelperExpireIn(timestampExpiration))
 	repo.SetTimestamp(timestamp)
 
-	// Add targets to snapshot meta
-	snapshot.Signed.Meta["targets.json"] = metadata.MetaFile(int64(targets.Signed.Version))
-
 	if payload.Settings.Roles.Delegations != nil {
 		logrus.Debug("Creating custom delegations")
 		customDelegations := payload.Settings.Roles.Delegations
@@ -240,9 +233,6 @@ func BootstrapOnlineRolesWithContext(
 
 			repo.SetTargets(roleName, roleTargets)
 
-			// Add role to snapshot meta
-			snapshot.Signed.Meta[fmt.Sprintf("%s.json", roleName)] = metadata.MetaFile(1)
-
 			roleKeyIDs := delegatedRoles[i].KeyIDs
 			if len(roleKeyIDs) == 0 {
 				logrus.Errorf("No key IDs found for delegated role %s", roleName)
@@ -275,6 +265,11 @@ func BootstrapOnlineRolesWithContext(
 				logrus.Errorf("Failed to persist delegated role metadata %s: %v", roleName, err)
 				return fmt.Errorf("failed to persist delegated role metadata %s: %w", roleName, err)
 			}
+			roleMF, err := metaFileFromPath(rolePath, 1)
+			if err != nil {
+				return fmt.Errorf("failed to compute hash for delegated role %s: %w", roleName, err)
+			}
+			snapshot.Signed.Meta[fmt.Sprintf("%s.json", roleName)] = roleMF
 			logrus.Debugf("Successfully persisted delegated role metadata: %s", filename)
 
 			if err := tuf_storage.UploadMetadataToS3(ctx, adminName, appName, filename, rolePath); err != nil {
@@ -291,8 +286,6 @@ func BootstrapOnlineRolesWithContext(
 		timestampMeta = make(map[string]*metadata.MetaFiles)
 		repo.Timestamp().Signed.Meta = timestampMeta
 	}
-	timestampMeta["snapshot.json"] = metadata.MetaFile(int64(repo.Snapshot().Signed.Version))
-	logrus.Debugf("Timestamp metadata references snapshot version %d", repo.Snapshot().Signed.Version)
 
 	for i, s := range targetsSigners {
 		if _, err := repo.Targets("targets").Sign(s); err != nil {
@@ -302,6 +295,18 @@ func BootstrapOnlineRolesWithContext(
 	}
 	logrus.Debug("Successfully signed targets metadata")
 
+	// Write signed targets now so we can compute its hash for snapshot.
+	bootstrapTargetsFilename := fmt.Sprintf("%d.targets.json", targets.Signed.Version)
+	bootstrapTargetsPath := filepath.Join(tmpDir, bootstrapTargetsFilename)
+	if err := repo.Targets("targets").ToFile(bootstrapTargetsPath, true); err != nil {
+		return fmt.Errorf("failed to write targets for hash computation: %w", err)
+	}
+	targetsMF, err := metaFileFromPath(bootstrapTargetsPath, int64(targets.Signed.Version))
+	if err != nil {
+		return fmt.Errorf("failed to compute targets hash: %w", err)
+	}
+	snapshot.Signed.Meta["targets.json"] = targetsMF
+
 	for i, s := range snapshotSigners {
 		if _, err := repo.Snapshot().Sign(s); err != nil {
 			logrus.Errorf("Failed to sign snapshot metadata with key %d: %v", i+1, err)
@@ -309,6 +314,19 @@ func BootstrapOnlineRolesWithContext(
 		}
 	}
 	logrus.Debug("Successfully signed snapshot metadata")
+
+	// Write signed snapshot now so we can compute its hash for timestamp.
+	bootstrapSnapshotFilename := fmt.Sprintf("%d.snapshot.json", snapshot.Signed.Version)
+	bootstrapSnapshotPath := filepath.Join(tmpDir, bootstrapSnapshotFilename)
+	if err := repo.Snapshot().ToFile(bootstrapSnapshotPath, true); err != nil {
+		return fmt.Errorf("failed to write snapshot for hash computation: %w", err)
+	}
+	snapshotMF, err := metaFileFromPath(bootstrapSnapshotPath, int64(snapshot.Signed.Version))
+	if err != nil {
+		return fmt.Errorf("failed to compute snapshot hash: %w", err)
+	}
+	timestampMeta["snapshot.json"] = snapshotMF
+	logrus.Debugf("Timestamp metadata references snapshot version %d", snapshot.Signed.Version)
 
 	for i, s := range timestampSigners {
 		if _, err := repo.Timestamp().Sign(s); err != nil {
@@ -400,13 +418,7 @@ func PostMetadataRotate(c *gin.Context, redisClient *redis.Client) {
 		return
 	}
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		logrus.Errorf("Failed to get current working directory: %v", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
-		return
-	}
-	tmpDir, err := os.MkdirTemp(cwd, "tmp-metadata-*")
+	tmpDir, err := os.MkdirTemp("", "tmp-metadata-*")
 	if err != nil {
 		logrus.Errorf("Failed to create temporary directory: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
@@ -474,7 +486,7 @@ func PostMetadataRotate(c *gin.Context, redisClient *redis.Client) {
 	newRootMeta := newRepo.Root()
 	if err := verifyNewRootMetadata(currentRootMeta, newRootMeta); err != nil {
 
-		if strings.Contains(err.Error(), "unsigned") || strings.Contains(err.Error(), "signature") {
+		if errors.Is(err, errRootSignaturesMissing) {
 			taskID := uuid.New().String()
 			logrus.Debugf("Generated task_id: %s", taskID)
 			if err := stageMetadataForSigning(ctx, redisClient, keySuffix, "ROOT", newRootJSON, taskID); err != nil {
@@ -762,6 +774,10 @@ func GetMetadataSign(c *gin.Context, redisClient *redis.Client) {
 		})
 		return
 	}
+	if err := tuf_utils.ValidateAppName(appName); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
 
 	if redisClient == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{
@@ -818,9 +834,16 @@ func GetMetadataSign(c *gin.Context, redisClient *redis.Client) {
 	// Also check for delegated roles (custom roles)
 	// Search for keys matching pattern: *_SIGNING_{adminName}_{appName}
 	pattern := "*_SIGNING_" + keySuffix
-	allSigningKeys, err := redisClient.Keys(ctx, pattern).Result()
-	if err == nil {
-		for _, key := range allSigningKeys {
+	var scanCursor uint64
+	for {
+		var batch []string
+		var scanErr error
+		batch, scanCursor, scanErr = redisClient.Scan(ctx, scanCursor, pattern, 100).Result()
+		if scanErr != nil {
+			logrus.Warnf("Failed to scan Redis for delegated signing keys: %v", scanErr)
+			break
+		}
+		for _, key := range batch {
 			parts := strings.Split(key, "_SIGNING_")
 			if len(parts) == 2 {
 				role := parts[0]
@@ -846,6 +869,9 @@ func GetMetadataSign(c *gin.Context, redisClient *redis.Client) {
 					}
 				}
 			}
+		}
+		if scanCursor == 0 {
+			break
 		}
 	}
 
@@ -915,6 +941,10 @@ func PostMetadataSign(c *gin.Context, redisClient *redis.Client) {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error": "appName query parameter is required",
 		})
+		return
+	}
+	if err := tuf_utils.ValidateAppName(appName); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
@@ -1046,13 +1076,7 @@ func PostMetadataSign(c *gin.Context, redisClient *redis.Client) {
 		metadataJSON["signatures"] = signatures
 	}
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		logrus.Errorf("Failed to get current working directory: %v", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
-		return
-	}
-	tmpDir, err := os.MkdirTemp(cwd, "tmp-sign-*")
+	tmpDir, err := os.MkdirTemp("", "tmp-sign-*")
 	if err != nil {
 		logrus.Errorf("Failed to create temporary directory: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
@@ -1090,7 +1114,9 @@ func PostMetadataSign(c *gin.Context, redisClient *redis.Client) {
 	if err == redis.Nil || taskIDStr == "" {
 		taskID = uuid.New().String()
 		logrus.Debugf("Generated new task_id: %s", taskID)
-		redisClient.Set(ctx, taskKey, taskID, 0)
+		if setErr := redisClient.Set(ctx, taskKey, taskID, stagedSigningDataTTL).Err(); setErr != nil {
+			logrus.Warnf("Failed to persist signing task_id %s: %v", taskID, setErr)
+		}
 	} else {
 		taskID = taskIDStr
 		logrus.Debugf("Using existing task_id: %s", taskID)
@@ -1191,13 +1217,26 @@ func PostMetadataSign(c *gin.Context, redisClient *redis.Client) {
 				})
 				return
 			}
-			redisClient.Del(ctx, signingKey)
-			redisClient.Del(ctx, taskKey)
+			if delErr := redisClient.Del(ctx, signingKey).Err(); delErr != nil {
+				logrus.Warnf("Failed to clear signing key %s after finalization: %v", signingKey, delErr)
+			}
+			if delErr := redisClient.Del(ctx, taskKey).Err(); delErr != nil {
+				logrus.Warnf("Failed to clear task key %s after finalization: %v", taskKey, delErr)
+			}
 			logrus.Infof("Root metadata update finalized and signing key cleared from Redis")
 		} else {
 			logrus.Infof("Threshold not reached - saving updated metadata back to Redis (error: %v)", validationError)
-			updatedJSON, _ := json.Marshal(metadataJSON)
-			redisClient.Set(ctx, signingKey, string(updatedJSON), 0)
+			updatedJSON, err := json.Marshal(metadataJSON)
+			if err != nil {
+				logrus.Errorf("Failed to marshal updated root metadata: %v", err)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save signing progress"})
+				return
+			}
+			if setErr := redisClient.Set(ctx, signingKey, string(updatedJSON), stagedSigningDataTTL).Err(); setErr != nil {
+				logrus.Errorf("Failed to save signing progress for root: %v", setErr)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save signing progress"})
+				return
+			}
 		}
 	case "targets":
 		targets := metadata.Targets(time.Now().Add(365 * 24 * time.Hour))
@@ -1211,53 +1250,62 @@ func PostMetadataSign(c *gin.Context, redisClient *redis.Client) {
 		}
 
 		_, targetsFilename, err := tuf_storage.FindLatestMetadataVersion(ctx, adminName, appName, "targets")
-		if err == nil {
-			targetsPath := filepath.Join(tmpDir, targetsFilename)
-			if err := tuf_storage.DownloadMetadataFromS3(ctx, adminName, appName, targetsFilename, targetsPath); err == nil {
-				trustedTargets := metadata.Targets(time.Now().Add(365 * 24 * time.Hour))
-				trustedRepo := repository.New()
-				trustedRepo.SetTargets("targets", trustedTargets)
-				if _, err := trustedRepo.Targets("targets").FromFile(targetsPath); err == nil {
-					if payload.Role == "targets" {
-						trustedRoleVersion := int64(trustedRepo.Targets("targets").Signed.Version)
-						if int64(repo.Targets(payload.Role).Signed.Version) <= trustedRoleVersion {
-							validationError = fmt.Errorf("version must be greater than trusted version %d", trustedRoleVersion)
-							thresholdReached = false
-							break
-						}
+		if err != nil {
+			validationError = fmt.Errorf("failed to find trusted targets metadata: %w", err)
+			thresholdReached = false
+			break
+		}
+		targetsPath := filepath.Join(tmpDir, targetsFilename)
+		if err := tuf_storage.DownloadMetadataFromS3(ctx, adminName, appName, targetsFilename, targetsPath); err != nil {
+			validationError = fmt.Errorf("failed to download trusted targets metadata: %w", err)
+			thresholdReached = false
+			break
+		}
+		trustedTargets := metadata.Targets(time.Now().Add(365 * 24 * time.Hour))
+		trustedRepo := repository.New()
+		trustedRepo.SetTargets("targets", trustedTargets)
+		if _, err := trustedRepo.Targets("targets").FromFile(targetsPath); err != nil {
+			validationError = fmt.Errorf("failed to load trusted targets metadata: %w", err)
+			thresholdReached = false
+			break
+		}
+		if payload.Role == "targets" {
+			trustedRoleVersion := int64(trustedRepo.Targets("targets").Signed.Version)
+			if int64(repo.Targets(payload.Role).Signed.Version) <= trustedRoleVersion {
+				validationError = fmt.Errorf("version must be greater than trusted version %d", trustedRoleVersion)
+				thresholdReached = false
+				break
+			}
 
-						trustedRootMeta, loadErr := loadTrustedRootMetadataFromS3(ctx, adminName, appName)
-						if loadErr != nil {
-							validationError = fmt.Errorf("failed to load trusted root metadata: %w", loadErr)
-							thresholdReached = false
-							break
-						}
+			trustedRootMeta, loadErr := loadTrustedRootMetadataFromS3(ctx, adminName, appName)
+			if loadErr != nil {
+				validationError = fmt.Errorf("failed to load trusted root metadata: %w", loadErr)
+				thresholdReached = false
+				break
+			}
 
-						if err := trustedRootMeta.VerifyDelegate("targets", repo.Targets(payload.Role)); err != nil {
-							validationError = err
-							thresholdReached = false
-						} else {
-							thresholdReached = true
-						}
-					} else {
-						trustedRole, loadErr := loadTrustedTargetsMetadataFromS3(ctx, adminName, appName, payload.Role)
-						if loadErr != nil {
-							validationError = fmt.Errorf("failed to load trusted delegated role %s: %w", payload.Role, loadErr)
-							thresholdReached = false
-							break
-						}
-						trustedRoleVersion := int64(trustedRole.Signed.Version)
-						if int64(repo.Targets(payload.Role).Signed.Version) <= trustedRoleVersion {
-							validationError = fmt.Errorf("version must be greater than trusted version %d", trustedRoleVersion)
-							thresholdReached = false
-						} else if err := trustedRepo.Targets("targets").VerifyDelegate(payload.Role, repo.Targets(payload.Role)); err != nil {
-							validationError = err
-							thresholdReached = false
-						} else {
-							thresholdReached = true
-						}
-					}
-				}
+			if err := trustedRootMeta.VerifyDelegate("targets", repo.Targets(payload.Role)); err != nil {
+				validationError = err
+				thresholdReached = false
+			} else {
+				thresholdReached = true
+			}
+		} else {
+			trustedRole, loadErr := loadTrustedTargetsMetadataFromS3(ctx, adminName, appName, payload.Role)
+			if loadErr != nil {
+				validationError = fmt.Errorf("failed to load trusted delegated role %s: %w", payload.Role, loadErr)
+				thresholdReached = false
+				break
+			}
+			trustedRoleVersion := int64(trustedRole.Signed.Version)
+			if int64(repo.Targets(payload.Role).Signed.Version) <= trustedRoleVersion {
+				validationError = fmt.Errorf("version must be greater than trusted version %d", trustedRoleVersion)
+				thresholdReached = false
+			} else if err := trustedRepo.Targets("targets").VerifyDelegate(payload.Role, repo.Targets(payload.Role)); err != nil {
+				validationError = err
+				thresholdReached = false
+			} else {
+				thresholdReached = true
 			}
 		}
 
@@ -1270,12 +1318,24 @@ func PostMetadataSign(c *gin.Context, redisClient *redis.Client) {
 				return
 			}
 
-			redisClient.Del(ctx, signingKey)
-			redisClient.Del(ctx, taskKey)
+			if delErr := redisClient.Del(ctx, signingKey).Err(); delErr != nil {
+				logrus.Warnf("Failed to clear signing key %s after finalization: %v", signingKey, delErr)
+			}
+			if delErr := redisClient.Del(ctx, taskKey).Err(); delErr != nil {
+				logrus.Warnf("Failed to clear task key %s after finalization: %v", taskKey, delErr)
+			}
 		} else {
-
-			updatedJSON, _ := json.Marshal(metadataJSON)
-			redisClient.Set(ctx, signingKey, string(updatedJSON), 0)
+			updatedJSON, err := json.Marshal(metadataJSON)
+			if err != nil {
+				logrus.Errorf("Failed to marshal updated targets metadata: %v", err)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save signing progress"})
+				return
+			}
+			if setErr := redisClient.Set(ctx, signingKey, string(updatedJSON), stagedSigningDataTTL).Err(); setErr != nil {
+				logrus.Errorf("Failed to save signing progress for %s: %v", payload.Role, setErr)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save signing progress"})
+				return
+			}
 		}
 	default:
 		c.JSON(http.StatusBadRequest, gin.H{

--- a/server/tuf/metadata/metadata.go
+++ b/server/tuf/metadata/metadata.go
@@ -1167,39 +1167,20 @@ func PostMetadataSign(c *gin.Context, redisClient *redis.Client) {
 			}
 		} else {
 			logrus.Debugf("Metadata update: loading trusted root from S3")
-			trustedRoot, err := loadTrustedRootFromS3(ctx, adminName, appName)
+			trustedRootMeta, err := loadTrustedRootMetadataFromS3(ctx, adminName, appName)
 			if err == nil {
-				trustedRootPath := filepath.Join(tmpDir, "trusted_root.json")
-				trustedRootJSON, _ := json.Marshal(trustedRoot)
-				if writeErr := os.WriteFile(trustedRootPath, trustedRootJSON, 0644); writeErr != nil {
-					logrus.Warnf("Failed to persist trusted root locally: %v", writeErr)
-					validationError = fmt.Errorf("trusted root is required for root rotation: %w", writeErr)
-					thresholdReached = false
-					break
-				}
+				trustedRootRole := trustedRootMeta.Signed.Roles["root"]
+				oldKeyIDs = trustedRootRole.KeyIDs
+				isRootRotation = true
 
-				trustedRepo := repository.New()
-				trustedRootMeta := metadata.Root(time.Now().Add(365 * 24 * time.Hour))
-				trustedRepo.SetRoot(trustedRootMeta)
-				if _, parseErr := trustedRepo.Root().FromFile(trustedRootPath); parseErr == nil {
-
-					trustedRootRole := trustedRepo.Root().Signed.Roles["root"]
-					oldKeyIDs = trustedRootRole.KeyIDs
-					isRootRotation = true
-
-					logrus.Debugf("Validating new root against trusted root and itself")
-					if err := verifyNewRootMetadata(trustedRepo.Root(), repo.Root()); err == nil {
-						logrus.Infof("Root rotation verification succeeded: threshold reached with trusted and new root signatures")
-						thresholdReached = true
-					} else {
-						logrus.Warnf("Root rotation verification failed: %v", err)
-						thresholdReached = false
-						validationError = err
-					}
+				logrus.Debugf("Validating new root against trusted root and itself")
+				if err := verifyNewRootMetadata(trustedRootMeta, repo.Root()); err == nil {
+					logrus.Infof("Root rotation verification succeeded: threshold reached with trusted and new root signatures")
+					thresholdReached = true
 				} else {
-					logrus.Warnf("Failed to load trusted root from file: %v", parseErr)
-					validationError = fmt.Errorf("trusted root is required for root rotation: %w", parseErr)
+					logrus.Warnf("Root rotation verification failed: %v", err)
 					thresholdReached = false
+					validationError = err
 				}
 			} else {
 				logrus.Warnf("Failed to load trusted root from S3: %v", err)

--- a/server/tuf/metadata/metadata_delete.go
+++ b/server/tuf/metadata/metadata_delete.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"faynoSync/server/tuf/models"
 	"faynoSync/server/tuf/tasks"
+	tuf_utils "faynoSync/server/tuf/utils"
 	"faynoSync/server/utils"
 	"fmt"
 	"net/http"
@@ -29,6 +30,10 @@ func PostMetadataSignDelete(c *gin.Context, redisClient *redis.Client) {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error": "appName query parameter is required",
 		})
+		return
+	}
+	if err := tuf_utils.ValidateAppName(appName); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/server/tuf/metadata/metadata_online.go
+++ b/server/tuf/metadata/metadata_online.go
@@ -40,6 +40,10 @@ func PostMetadataOnline(c *gin.Context, redisClient *redis.Client) {
 		})
 		return
 	}
+	if err := tuf_utils.ValidateAppName(appName); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
 
 	if redisClient == nil {
 		c.JSON(http.StatusServiceUnavailable, gin.H{
@@ -203,11 +207,7 @@ func forceOnlineMetadataUpdate(
 ) ([]string, error) {
 	keySuffix := adminName + "_" + appName
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get current working directory: %w", err)
-	}
-	tmpDir, err := os.MkdirTemp(cwd, "tmp-tuf-*")
+	tmpDir, err := os.MkdirTemp("", "tmp-tuf-*")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temporary directory: %w", err)
 	}
@@ -542,7 +542,13 @@ func bumpSnapshotRole(
 
 	targets := repo.Targets("targets")
 	if targets != nil {
-		snapshotMeta["targets.json"] = metadata.MetaFile(int64(targets.Signed.Version))
+		targetsFile := filepath.Join(tmpDir, fmt.Sprintf("%d.targets.json", targets.Signed.Version))
+		if mf, err := metaFileFromPath(targetsFile, int64(targets.Signed.Version)); err == nil {
+			snapshotMeta["targets.json"] = mf
+		} else {
+			logrus.Warnf("Failed to compute targets hash for snapshot, using version-only: %v", err)
+			snapshotMeta["targets.json"] = metadata.MetaFile(int64(targets.Signed.Version))
+		}
 	}
 
 	if targets != nil && targets.Signed.Delegations != nil {
@@ -551,7 +557,13 @@ func bumpSnapshotRole(
 				delegation := repo.Targets(role.Name)
 				if delegation != nil {
 					metaFilename := fmt.Sprintf("%s.json", role.Name)
-					snapshotMeta[metaFilename] = metadata.MetaFile(int64(delegation.Signed.Version))
+					delegationFile := filepath.Join(tmpDir, fmt.Sprintf("%d.%s.json", delegation.Signed.Version, role.Name))
+					if mf, err := metaFileFromPath(delegationFile, int64(delegation.Signed.Version)); err == nil {
+						snapshotMeta[metaFilename] = mf
+					} else {
+						logrus.Warnf("Failed to compute %s hash for snapshot, using version-only: %v", role.Name, err)
+						snapshotMeta[metaFilename] = metadata.MetaFile(int64(delegation.Signed.Version))
+					}
 				}
 			}
 		}
@@ -616,9 +628,38 @@ func bumpTimestampRole(
 	}
 
 	snapshot := repo.Snapshot()
+	if snapshot == nil {
+		// Snapshot not in memory (e.g. timestamp-only bump): load from S3 so the
+		// new timestamp always carries a valid snapshot reference.
+		_, snapshotFilename, findErr := tuf_storage.FindLatestMetadataVersion(ctx, adminName, appName, "snapshot")
+		if findErr == nil {
+			snapshotDlPath := filepath.Join(tmpDir, snapshotFilename)
+			if dlErr := tuf_storage.DownloadMetadataFromS3(ctx, adminName, appName, snapshotFilename, snapshotDlPath); dlErr == nil {
+				snapshotExpiration := tuf_utils.GetExpirationFromRedis(redisClient, ctx, "SNAPSHOT_EXPIRATION_"+keySuffix, 7)
+				snap := metadata.Snapshot(tuf_utils.HelperExpireIn(snapshotExpiration))
+				repo.SetSnapshot(snap)
+				if _, loadErr := repo.Snapshot().FromFile(snapshotDlPath); loadErr == nil {
+					snapshot = repo.Snapshot()
+				} else {
+					logrus.Warnf("Failed to load snapshot for timestamp reference: %v", loadErr)
+				}
+			} else {
+				logrus.Warnf("Failed to download snapshot for timestamp reference: %v", dlErr)
+			}
+		} else {
+			logrus.Warnf("Failed to find snapshot version for timestamp reference: %v", findErr)
+		}
+	}
 	if snapshot != nil {
-		snapshotMetaFile := metadata.MetaFile(int64(snapshot.Signed.Version))
-		timestampMeta["snapshot.json"] = snapshotMetaFile
+		snapshotFile := filepath.Join(tmpDir, fmt.Sprintf("%d.snapshot.json", snapshot.Signed.Version))
+		if mf, err := metaFileFromPath(snapshotFile, int64(snapshot.Signed.Version)); err == nil {
+			timestampMeta["snapshot.json"] = mf
+		} else {
+			logrus.Warnf("Failed to compute snapshot hash for timestamp, using version-only: %v", err)
+			timestampMeta["snapshot.json"] = metadata.MetaFile(int64(snapshot.Signed.Version))
+		}
+	} else {
+		logrus.Warnf("Snapshot not available; timestamp will be signed without a snapshot reference")
 	}
 	if loadedTimestamp {
 		repo.Timestamp().Signed.Version++

--- a/server/tuf/metadata/metadata_online.go
+++ b/server/tuf/metadata/metadata_online.go
@@ -543,12 +543,11 @@ func bumpSnapshotRole(
 	targets := repo.Targets("targets")
 	if targets != nil {
 		targetsFile := filepath.Join(tmpDir, fmt.Sprintf("%d.targets.json", targets.Signed.Version))
-		if mf, err := metaFileFromPath(targetsFile, int64(targets.Signed.Version)); err == nil {
-			snapshotMeta["targets.json"] = mf
-		} else {
-			logrus.Warnf("Failed to compute targets hash for snapshot, using version-only: %v", err)
-			snapshotMeta["targets.json"] = metadata.MetaFile(int64(targets.Signed.Version))
+		mf, err := metaFileFromPath(targetsFile, int64(targets.Signed.Version))
+		if err != nil {
+			return fmt.Errorf("failed to compute targets hash for snapshot: %w", err)
 		}
+		snapshotMeta["targets.json"] = mf
 	}
 
 	if targets != nil && targets.Signed.Delegations != nil {
@@ -558,12 +557,11 @@ func bumpSnapshotRole(
 				if delegation != nil {
 					metaFilename := fmt.Sprintf("%s.json", role.Name)
 					delegationFile := filepath.Join(tmpDir, fmt.Sprintf("%d.%s.json", delegation.Signed.Version, role.Name))
-					if mf, err := metaFileFromPath(delegationFile, int64(delegation.Signed.Version)); err == nil {
-						snapshotMeta[metaFilename] = mf
-					} else {
-						logrus.Warnf("Failed to compute %s hash for snapshot, using version-only: %v", role.Name, err)
-						snapshotMeta[metaFilename] = metadata.MetaFile(int64(delegation.Signed.Version))
+					mf, err := metaFileFromPath(delegationFile, int64(delegation.Signed.Version))
+					if err != nil {
+						return fmt.Errorf("failed to compute %s hash for snapshot: %w", role.Name, err)
 					}
+					snapshotMeta[metaFilename] = mf
 				}
 			}
 		}
@@ -652,12 +650,11 @@ func bumpTimestampRole(
 	}
 	if snapshot != nil {
 		snapshotFile := filepath.Join(tmpDir, fmt.Sprintf("%d.snapshot.json", snapshot.Signed.Version))
-		if mf, err := metaFileFromPath(snapshotFile, int64(snapshot.Signed.Version)); err == nil {
-			timestampMeta["snapshot.json"] = mf
-		} else {
-			logrus.Warnf("Failed to compute snapshot hash for timestamp, using version-only: %v", err)
-			timestampMeta["snapshot.json"] = metadata.MetaFile(int64(snapshot.Signed.Version))
+		mf, err := metaFileFromPath(snapshotFile, int64(snapshot.Signed.Version))
+		if err != nil {
+			return fmt.Errorf("failed to compute snapshot hash for timestamp: %w", err)
 		}
+		timestampMeta["snapshot.json"] = mf
 	} else {
 		logrus.Warnf("Snapshot not available; timestamp will be signed without a snapshot reference")
 	}

--- a/server/tuf/metadata/metadata_root.go
+++ b/server/tuf/metadata/metadata_root.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	"context"
 	"errors"
+	tuf_utils "faynoSync/server/tuf/utils"
 	"faynoSync/server/utils"
 	"net/http"
 
@@ -51,6 +52,10 @@ func getTrustedMetadata(
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error": "appName query parameter is required",
 		})
+		return
+	}
+	if err := tuf_utils.ValidateAppName(appName); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 	ctx := context.Background()

--- a/server/tuf/metadata/metadata_signature_test.go
+++ b/server/tuf/metadata/metadata_signature_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	tuf_metadata "github.com/theupdateframework/go-tuf/v2/metadata"
 )
@@ -108,6 +109,51 @@ func runDelegatedTargetsSignatureValidationTest(t *testing.T, roleName string, p
 		signedData,
 		false,
 	)
+}
+
+// To verify: In loadTrustedRootMetadataFromS3 remove the expiration check; test will fail (no error for expired root).
+func TestLoadTrustedRootMetadataFromS3_ExpiredRoot_ReturnsError(t *testing.T) {
+	// A root with a past expiration must be rejected even if structurally valid.
+	expiredRoot := `{
+		"signatures": [],
+		"signed": {
+			"_type": "root",
+			"version": 1,
+			"spec_version": "1.0.0",
+			"expires": "2020-01-01T00:00:00Z",
+			"consistent_snapshot": false,
+			"keys": {},
+			"roles": {
+				"root":      {"keyids": [], "threshold": 1},
+				"targets":   {"keyids": [], "threshold": 1},
+				"snapshot":  {"keyids": [], "threshold": 1},
+				"timestamp": {"keyids": [], "threshold": 1}
+			}
+		}
+	}`
+
+	savedList := tuf_storage.ListMetadataForLatest
+	savedViper := tuf_storage.GetViperForDownload
+	savedFactory := tuf_storage.StorageFactoryForDownload
+	tuf_storage.ListMetadataForLatest = func(_ context.Context, _, _, _ string) ([]string, error) {
+		return []string{"1.root.json"}, nil
+	}
+	mockViper := viper.New()
+	mockViper.Set("S3_BUCKET_NAME", "test-bucket")
+	tuf_storage.GetViperForDownload = func() *viper.Viper { return mockViper }
+	tuf_storage.StorageFactoryForDownload = func(*viper.Viper) tuf_storage.StorageFactory {
+		return &forceUpdateMockFactory{client: &storageMockClientForForceUpdate{body: []byte(expiredRoot)}}
+	}
+	defer func() {
+		tuf_storage.ListMetadataForLatest = savedList
+		tuf_storage.GetViperForDownload = savedViper
+		tuf_storage.StorageFactoryForDownload = savedFactory
+	}()
+
+	_, err := loadTrustedRootMetadataFromS3(context.Background(), "admin", "app")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expired")
 }
 
 func loadTestSigner(privateKey crypto.Signer) (signature.Signer, error) {

--- a/server/tuf/metadata/metadata_test.go
+++ b/server/tuf/metadata/metadata_test.go
@@ -2640,3 +2640,188 @@ func TestLoadTrustedTargetsFromS3_Success_WithMockedStorage(t *testing.T) {
 	assert.Equal(t, "targets", result["signed"].(map[string]interface{})["_type"])
 	assert.Equal(t, float64(2), result["signed"].(map[string]interface{})["version"])
 }
+
+// --- C-2 regression: PostMetadataSign targets path returns 400 on S3 error (not silent 200) ---
+
+// To verify: (restore nested if-err==nil blocks); test will fail (200 instead of 400).
+func TestPostMetadataSign_Targets_S3UnavailableDuringVerification_ReturnsBadRequest(t *testing.T) {
+	// Build valid go-tuf targets JSON so FromFile succeeds inside the switch case.
+	targetsObj := tuf_metadata.Targets(time.Now().Add(365 * 24 * time.Hour))
+	targetsObj.Signed.Version = 2
+	stagedJSON := mustBuildTargetsJSON(t, targetsObj)
+
+	// Prepend the test signature keyID to the staged JSON so signatureExists=true,
+	// which skips validateIncomingMetadataSignature (avoiding S3 root lookup there).
+	var staged map[string]interface{}
+	require.NoError(t, json.Unmarshal(stagedJSON, &staged))
+	staged["signatures"] = []interface{}{map[string]interface{}{"keyid": "test-key", "sig": "aabb"}}
+	stagedWithSig, err := json.Marshal(staged)
+	require.NoError(t, err)
+
+	payload := models.MetadataSignPostPayload{
+		Role:      "targets",
+		Signature: models.Signature{KeyID: "test-key", Sig: "aabb"},
+	}
+	c, w := makePostMetadataSignContext("admin", "myapp", payload)
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	mr.Set("BOOTSTRAP_admin_myapp", "done")
+	mr.Set("TARGETS_SIGNING_admin_myapp", string(stagedWithSig))
+
+	savedList := tuf_storage.ListMetadataForLatest
+	tuf_storage.ListMetadataForLatest = func(_ context.Context, _, _, _ string) ([]string, error) {
+		return nil, fmt.Errorf("s3 unavailable")
+	}
+	defer func() { tuf_storage.ListMetadataForLatest = savedList }()
+
+	PostMetadataSign(c, client)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code, "S3 error during targets verification must return 400, not silent 200")
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, "Signature Failed", body["message"])
+	assert.Contains(t, body["error"], "failed to find trusted targets metadata")
+}
+
+// mustBuildTargetsJSON serialises a go-tuf Targets metadata object to canonical JSON bytes.
+func mustBuildTargetsJSON(t *testing.T, meta *tuf_metadata.Metadata[tuf_metadata.TargetsType]) []byte {
+	t.Helper()
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "targets.json")
+	require.NoError(t, meta.ToFile(path, true))
+	b, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return b
+}
+
+// --- C-4 regression: PostMetadataRotate stages correct-version root, rejects wrong-version root ---
+
+// To verify: (string matching instead of errors.Is); test will fail when a wrong-version root
+// with "signature"-containing error text is incorrectly staged instead of rejected.
+func TestPostMetadataRotate_CorrectVersionUnsignedRoot_IsStagedForSigning(t *testing.T) {
+	// Build a valid current root (v1, properly signed).
+	payload, _, cleanup := makeValidRootAndPayload(t)
+	defer cleanup()
+	currentRootMeta := payload.Metadata["root"]
+	currentRootJSON, err := json.Marshal(currentRootMeta)
+	require.NoError(t, err)
+
+	// Build a new root at v2 with a brand-new key so signatures from v1 keys are absent.
+	expires := time.Now().Add(365 * 24 * time.Hour)
+	newRepoObj := repository.New()
+	newRepoObj.SetRoot(tuf_metadata.Root(expires))
+	_, newPriv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	newKey, err := tuf_metadata.KeyFromPublicKey(newPriv.Public())
+	require.NoError(t, err)
+	for _, role := range []string{"root", "targets", "snapshot", "timestamp"} {
+		require.NoError(t, newRepoObj.Root().Signed.AddKey(newKey, role))
+	}
+	newRepoObj.Root().Signed.Version = 2
+	newRootPath := filepath.Join(t.TempDir(), "new_root.json")
+	require.NoError(t, newRepoObj.Root().ToFile(newRootPath, true))
+	newRootBytes, err := os.ReadFile(newRootPath)
+	require.NoError(t, err)
+	var newRootMeta models.RootMetadata
+	require.NoError(t, json.Unmarshal(newRootBytes, &newRootMeta))
+
+	// Mock download so PostMetadataRotate finds the current root.
+	savedList := tuf_storage.ListMetadataForLatest
+	savedViper := tuf_storage.GetViperForDownload
+	savedFactory := tuf_storage.StorageFactoryForDownload
+	mockViper := viper.New()
+	mockViper.Set("S3_BUCKET_NAME", "test-bucket")
+	tuf_storage.ListMetadataForLatest = func(_ context.Context, _, _, _ string) ([]string, error) {
+		return []string{"1.root.json"}, nil
+	}
+	tuf_storage.GetViperForDownload = func() *viper.Viper { return mockViper }
+	tuf_storage.StorageFactoryForDownload = func(*viper.Viper) tuf_storage.StorageFactory {
+		return &downloadMockFactory{client: &downloadMockClient{body: currentRootJSON}}
+	}
+	defer func() {
+		tuf_storage.ListMetadataForLatest = savedList
+		tuf_storage.GetViperForDownload = savedViper
+		tuf_storage.StorageFactoryForDownload = savedFactory
+	}()
+
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	mr.Set("BOOTSTRAP_admin_myapp", "done")
+
+	c, w := makePostMetadataRotateContext("admin", "myapp", models.MetadataPostPayload{
+		Metadata: map[string]models.RootMetadata{"root": newRootMeta},
+	})
+	PostMetadataRotate(c, client)
+
+	assert.Equal(t, http.StatusOK, w.Code, "Correct-version root with missing signatures must be staged (200)")
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, "Metadata Update Processed", body["message"])
+	require.NotNil(t, body["data"])
+	data := body["data"].(map[string]interface{})
+	assert.NotEmpty(t, data["task_id"], "taskID must be present when metadata is staged")
+}
+
+// To verify: test will fail when a wrong-version root is accepted instead of rejected with 400.
+func TestPostMetadataRotate_WrongVersionRoot_ReturnsBadRequest(t *testing.T) {
+	payload, _, cleanup := makeValidRootAndPayload(t)
+	defer cleanup()
+	currentRootMeta := payload.Metadata["root"]
+	currentRootJSON, err := json.Marshal(currentRootMeta)
+	require.NoError(t, err)
+
+	// New root jumps to version 5 — not current+1.
+	expires := time.Now().Add(365 * 24 * time.Hour)
+	newRepoObj := repository.New()
+	newRepoObj.SetRoot(tuf_metadata.Root(expires))
+	_, newPriv, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+	newKey, err := tuf_metadata.KeyFromPublicKey(newPriv.Public())
+	require.NoError(t, err)
+	for _, role := range []string{"root", "targets", "snapshot", "timestamp"} {
+		require.NoError(t, newRepoObj.Root().Signed.AddKey(newKey, role))
+	}
+	newRepoObj.Root().Signed.Version = 5
+	newRootPath := filepath.Join(t.TempDir(), "new_root.json")
+	require.NoError(t, newRepoObj.Root().ToFile(newRootPath, true))
+	newRootBytes, err := os.ReadFile(newRootPath)
+	require.NoError(t, err)
+	var newRootMeta models.RootMetadata
+	require.NoError(t, json.Unmarshal(newRootBytes, &newRootMeta))
+
+	savedList := tuf_storage.ListMetadataForLatest
+	savedViper := tuf_storage.GetViperForDownload
+	savedFactory := tuf_storage.StorageFactoryForDownload
+	mockViper := viper.New()
+	mockViper.Set("S3_BUCKET_NAME", "test-bucket")
+	tuf_storage.ListMetadataForLatest = func(_ context.Context, _, _, _ string) ([]string, error) {
+		return []string{"1.root.json"}, nil
+	}
+	tuf_storage.GetViperForDownload = func() *viper.Viper { return mockViper }
+	tuf_storage.StorageFactoryForDownload = func(*viper.Viper) tuf_storage.StorageFactory {
+		return &downloadMockFactory{client: &downloadMockClient{body: currentRootJSON}}
+	}
+	defer func() {
+		tuf_storage.ListMetadataForLatest = savedList
+		tuf_storage.GetViperForDownload = savedViper
+		tuf_storage.StorageFactoryForDownload = savedFactory
+	}()
+
+	mr := miniredis.RunT(t)
+	defer mr.Close()
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	mr.Set("BOOTSTRAP_admin_myapp", "done")
+
+	c, w := makePostMetadataRotateContext("admin", "myapp", models.MetadataPostPayload{
+		Metadata: map[string]models.RootMetadata{"root": newRootMeta},
+	})
+	PostMetadataRotate(c, client)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code, "Wrong-version root must be rejected with 400")
+	var body map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, "Metadata Update Failed", body["message"])
+	assert.Contains(t, body["error"], "expected root version 2")
+}

--- a/server/tuf/metadata/metadata_utils.go
+++ b/server/tuf/metadata/metadata_utils.go
@@ -3,8 +3,10 @@ package metadata
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"faynoSync/server/tuf/models"
 	"faynoSync/server/tuf/signing"
 	tuf_storage "faynoSync/server/tuf/storage"
@@ -76,6 +78,10 @@ func validateMetadataUpdatePreconditions(c *gin.Context, redisClient *redis.Clie
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error": "appName query parameter is required",
 		})
+		return nil, false
+	}
+	if err := tuf_utils.ValidateAppName(appName); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return nil, false
 	}
 
@@ -204,11 +210,7 @@ func ensureDelegationsKeysMatchKeyIDs(signedData map[string]interface{}) error {
 }
 
 func loadTrustedTargetsMetadataFromS3(ctx context.Context, adminName string, appName string, roleName string) (*metadata.Metadata[metadata.TargetsType], error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get current working directory: %w", err)
-	}
-	tmpDir, err := os.MkdirTemp(cwd, "tmp-trusted-role-*")
+	tmpDir, err := os.MkdirTemp("", "tmp-trusted-role-*")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temporary directory: %w", err)
 	}
@@ -229,15 +231,15 @@ func loadTrustedTargetsMetadataFromS3(ctx context.Context, adminName string, app
 		return nil, fmt.Errorf("failed to load %s metadata: %w", roleName, err)
 	}
 
+	if !targetsMeta.Signed.Expires.After(time.Now().UTC()) {
+		return nil, fmt.Errorf("trusted %s metadata is expired at %s", roleName, targetsMeta.Signed.Expires.UTC().Format(time.RFC3339))
+	}
+
 	return targetsMeta, nil
 }
 
 func loadTrustedRootBytesFromS3(ctx context.Context, adminName string, appName string) ([]byte, error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get current working directory: %w", err)
-	}
-	tmpDir, err := os.MkdirTemp(cwd, "tmp-trusted-root-*")
+	tmpDir, err := os.MkdirTemp("", "tmp-trusted-root-*")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temporary directory: %w", err)
 	}
@@ -269,9 +271,28 @@ func loadTrustedRootMetadataFromS3(ctx context.Context, adminName string, appNam
 		return nil, err
 	}
 
+	tmpDir, err := os.MkdirTemp("", "tmp-trusted-root-meta-*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temporary directory: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	rootPath := filepath.Join(tmpDir, "root.json")
+	if err := os.WriteFile(rootPath, rootData, 0600); err != nil {
+		return nil, fmt.Errorf("failed to write root metadata for parsing: %w", err)
+	}
+
 	rootMeta := metadata.Root(time.Now().Add(365 * 24 * time.Hour))
-	if err := json.Unmarshal(rootData, rootMeta); err != nil {
+	if _, err := rootMeta.FromFile(rootPath); err != nil {
 		return nil, fmt.Errorf("failed to load root metadata: %w", err)
+	}
+
+	if !rootMeta.Signed.Expires.After(time.Now().UTC()) {
+		return nil, fmt.Errorf("trusted root metadata is expired at %s", rootMeta.Signed.Expires.UTC().Format(time.RFC3339))
+	}
+
+	if err := rootMeta.VerifyDelegate("root", rootMeta); err != nil {
+		return nil, fmt.Errorf("trusted root metadata signature verification failed: %w", err)
 	}
 
 	return rootMeta, nil
@@ -463,6 +484,27 @@ func isTopLevelRole(roleName string) bool {
 	}
 }
 
+// errRootSignaturesMissing is returned by verifyNewRootMetadata when the
+// metadata is structurally valid but lacks sufficient signatures. Callers
+// use errors.Is to distinguish this from hard failures (wrong version/type).
+var errRootSignaturesMissing = errors.New("root signatures missing or insufficient")
+
+// metaFileFromPath reads path (which must already be written to disk) and
+// returns a MetaFiles entry with version, length, and SHA-256 hash. The hash
+// must match the bytes stored in S3 so clients can verify downloads.
+func metaFileFromPath(path string, version int64) (*metadata.MetaFiles, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s for hash computation: %w", path, err)
+	}
+	sum := sha256.Sum256(data)
+	return &metadata.MetaFiles{
+		Version: version,
+		Length:  int64(len(data)),
+		Hashes:  metadata.Hashes{"sha256": metadata.HexBytes(sum[:])},
+	}, nil
+}
+
 func verifyNewRootMetadata(currentRoot, newRoot *metadata.Metadata[metadata.RootType]) error {
 	if newRoot.Signed.Type != "root" {
 		return fmt.Errorf("expected 'root', got '%s'", newRoot.Signed.Type)
@@ -473,11 +515,11 @@ func verifyNewRootMetadata(currentRoot, newRoot *metadata.Metadata[metadata.Root
 	}
 
 	if err := currentRoot.VerifyDelegate("root", newRoot); err != nil {
-		return fmt.Errorf("new root not signed by trusted root: %w", err)
+		return fmt.Errorf("%w: new root not signed by trusted root: %v", errRootSignaturesMissing, err)
 	}
 
 	if err := newRoot.VerifyDelegate("root", newRoot); err != nil {
-		return fmt.Errorf("new root threshold not reached: %w", err)
+		return fmt.Errorf("%w: new root threshold not reached: %v", errRootSignaturesMissing, err)
 	}
 
 	return nil
@@ -498,11 +540,7 @@ func loadTrustedRootFromS3(ctx context.Context, adminName string, appName string
 }
 
 func loadTrustedTargetsFromS3(ctx context.Context, adminName string, appName string) (map[string]interface{}, error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get current working directory: %w", err)
-	}
-	tmpDir, err := os.MkdirTemp(cwd, "tmp-trusted-*")
+	tmpDir, err := os.MkdirTemp("", "tmp-trusted-*")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temporary directory: %w", err)
 	}
@@ -532,11 +570,7 @@ func loadTrustedTargetsFromS3(ctx context.Context, adminName string, appName str
 }
 
 func loadTrustedDelegatedFromS3(ctx context.Context, adminName string, appName string, roleName string) (map[string]interface{}, error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get current working directory: %w", err)
-	}
-	tmpDir, err := os.MkdirTemp(cwd, "tmp-trusted-*")
+	tmpDir, err := os.MkdirTemp("", "tmp-trusted-*")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create temporary directory: %w", err)
 	}
@@ -836,22 +870,6 @@ func finalizeRootMetadataUpdate(
 	return nil
 }
 
-// Maybe split this function into smaller, focused units?
-
-// this function handles multiple responsibilities: persisting targets, re-signing snapshot, and re-signing timestamp. Breaking it into smaller functions would improve testability and readability.
-
-// Example structure:
-
-// func finalizeTargetsMetadataUpdate(...) error {
-//     if err := saveAndUploadTargets(...); err != nil {
-//         return err
-//     }
-//     if err := updateAndSignSnapshot(...); err != nil {
-//         return err
-//     }
-//     return updateAndSignTimestamp(...)
-// }
-
 func finalizeTargetsMetadataUpdate(
 	ctx context.Context,
 	repo *repository.Type,
@@ -940,7 +958,11 @@ func finalizeTargetsMetadataUpdate(
 		return fmt.Errorf("failed to load snapshot metadata: %w", err)
 	}
 
-	repo.Snapshot().Signed.Meta[fmt.Sprintf("%s.json", roleName)] = metadata.MetaFile(int64(targets.Signed.Version))
+	targetsMF, err := metaFileFromPath(targetsPath, int64(targets.Signed.Version))
+	if err != nil {
+		return fmt.Errorf("failed to compute hash for %s: %w", roleName, err)
+	}
+	repo.Snapshot().Signed.Meta[fmt.Sprintf("%s.json", roleName)] = targetsMF
 	repo.Snapshot().Signed.Version++
 	repo.Snapshot().Signed.Expires = tuf_utils.HelperExpireIn(snapshotExpiration)
 	repo.Snapshot().ClearSignatures()
@@ -986,7 +1008,11 @@ func finalizeTargetsMetadataUpdate(
 		timestampMeta = make(map[string]*metadata.MetaFiles)
 		repo.Timestamp().Signed.Meta = timestampMeta
 	}
-	timestampMeta["snapshot.json"] = metadata.MetaFile(int64(repo.Snapshot().Signed.Version))
+	snapshotMF, err := metaFileFromPath(newSnapshotPath, int64(repo.Snapshot().Signed.Version))
+	if err != nil {
+		return fmt.Errorf("failed to compute snapshot hash for timestamp: %w", err)
+	}
+	timestampMeta["snapshot.json"] = snapshotMF
 
 	if loadedTimestamp {
 		repo.Timestamp().Signed.Version++

--- a/server/tuf/tasks/task.go
+++ b/server/tuf/tasks/task.go
@@ -11,6 +11,23 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	// taskActiveTTL caps how long an in-progress task record lives in Redis.
+	taskActiveTTL = 24 * time.Hour
+	// taskTerminalTTL keeps completed/failed records for 7 days for audit/debugging.
+	taskTerminalTTL = 7 * 24 * time.Hour
+)
+
+func taskTTL(state TaskState) time.Duration {
+	switch state {
+	case TaskStateSuccess, TaskStateFailure, TaskStateRevoked,
+		TaskStateRejected, TaskStateIgnored, TaskStateErrored:
+		return taskTerminalTTL
+	default:
+		return taskActiveTTL
+	}
+}
+
 // GetTask retrieves task status from Redis
 func GetTask(c *gin.Context, redisClient *redis.Client) {
 	taskID := c.Query("task_id")
@@ -113,7 +130,7 @@ func SaveTaskStatus(redisClient *redis.Client, taskID string, state TaskState, r
 		return err
 	}
 
-	err = redisClient.Set(ctx, taskKey, taskJSON, 0).Err()
+	err = redisClient.Set(ctx, taskKey, taskJSON, taskTTL(state)).Err()
 	if err != nil {
 		logrus.Errorf("Failed to save task status to Redis: %v", err)
 		return err
@@ -169,7 +186,7 @@ func UpdateTaskState(redisClient *redis.Client, taskID string, state TaskState) 
 		return err
 	}
 
-	err = redisClient.Set(ctx, taskKey, taskJSON, 0).Err()
+	err = redisClient.Set(ctx, taskKey, taskJSON, taskTTL(state)).Err()
 	if err != nil {
 		logrus.Errorf("Failed to update task state in Redis: %v", err)
 		return err
@@ -224,7 +241,7 @@ func UpdateTaskResult(redisClient *redis.Client, taskID string, result *TaskResu
 		return err
 	}
 
-	err = redisClient.Set(ctx, taskKey, taskJSON, 0).Err()
+	err = redisClient.Set(ctx, taskKey, taskJSON, taskTTL(taskStatus.State)).Err()
 	if err != nil {
 		logrus.Errorf("Failed to update task result in Redis: %v", err)
 		return err

--- a/server/tuf/utils/utils.go
+++ b/server/tuf/utils/utils.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"time"
 
 	"github.com/go-redis/redis/v8"
@@ -15,18 +16,33 @@ import (
 	"github.com/spf13/viper"
 )
 
+// validAppNameRe allows alphanumeric characters and hyphens only.
+// Underscores are intentionally excluded: the Redis key separator is "_",
+// so allowing "_" in appName would allow key collisions between different
+// admin/app combinations (e.g. admin="a_b" + app="c" vs admin="a" + app="b_c").
+var validAppNameRe = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9-]*$`)
+
+// ValidateAppName returns an error if appName contains characters that
+// could cause Redis key collisions or S3 path injection.
+func ValidateAppName(appName string) error {
+	if !validAppNameRe.MatchString(appName) {
+		return fmt.Errorf("appName %q is invalid: only alphanumeric characters and hyphens are allowed, and it must start with an alphanumeric character", appName)
+	}
+	return nil
+}
+
 func HelperExpireIn(days int) time.Time {
 	return time.Now().AddDate(0, 0, days).UTC()
 }
 
-// helperGetPathForTarget returns local and target paths for target (?)
-func HelperGetPathForTarget(name string) (string, string) {
+// HelperGetPathForTarget returns local and target paths for the named target.
+func HelperGetPathForTarget(name string) (string, string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
-		panic(fmt.Sprintln("TUF:", "getting cwd failed", err))
+		return "", "", fmt.Errorf("getting cwd failed: %w", err)
 	}
 
-	return name, filepath.Join(cwd, name)
+	return name, filepath.Join(cwd, name), nil
 }
 
 func GetExpirationFromRedis(redisClient *redis.Client, ctx context.Context, key string, defaultValue int) int {
@@ -43,13 +59,12 @@ func GetExpirationFromRedis(redisClient *redis.Client, ctx context.Context, key 
 	return value
 }
 
-func CalculateExpirationDays(expiresStr string) int {
+func CalculateExpirationDays(expiresStr string) (int, error) {
 	expires, err := time.Parse(time.RFC3339, expiresStr)
 	if err != nil {
 		expires, err = time.Parse("2006-01-02T15:04:05.999999999Z", expiresStr)
 		if err != nil {
-			logrus.Warnf("Could not parse expiration date: %s, using default", expiresStr)
-			return 365
+			return 0, fmt.Errorf("could not parse expiration date %q: %w", expiresStr, err)
 		}
 	}
 
@@ -61,7 +76,7 @@ func CalculateExpirationDays(expiresStr string) int {
 		days = 1
 	}
 
-	return days
+	return days, nil
 }
 
 func CalculatePathHash(path string) string {

--- a/server/tuf/utils/utils_test.go
+++ b/server/tuf/utils/utils_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/alicebob/miniredis/v2"
 	"github.com/go-redis/redis/v8"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetExpirationFromRedis_ReturnsRedisValue(t *testing.T) {
@@ -94,8 +95,9 @@ func TestCalculateExpirationDays_ValidRFC3339(t *testing.T) {
 	expiresStr := futureDate.Format(time.RFC3339)
 	expectedDays := 30
 
-	result := CalculateExpirationDays(expiresStr)
+	result, err := CalculateExpirationDays(expiresStr)
 
+	require.NoError(t, err)
 	assert.GreaterOrEqual(t, result, expectedDays-1, "Result should be at least %d days", expectedDays-1)
 	assert.LessOrEqual(t, result, expectedDays+1, "Result should be at most %d days", expectedDays+1)
 }
@@ -107,21 +109,22 @@ func TestCalculateExpirationDays_ValidAlternativeFormat(t *testing.T) {
 	expiresStr := futureDate.Format("2006-01-02T15:04:05.999999999Z")
 	expectedDays := 60
 
-	result := CalculateExpirationDays(expiresStr)
+	result, err := CalculateExpirationDays(expiresStr)
 
+	require.NoError(t, err)
 	assert.GreaterOrEqual(t, result, expectedDays-1, "Result should be at least %d days", expectedDays-1)
 	assert.LessOrEqual(t, result, expectedDays+1, "Result should be at most %d days", expectedDays+1)
 }
 
-// To verify: Modify CalculateExpirationDays to return 0
+// To verify: Modify CalculateExpirationDays to not return an error for invalid input
 func TestCalculateExpirationDays_InvalidFormat(t *testing.T) {
 
 	expiresStr := "invalid-date-format"
-	defaultValue := 365
 
-	result := CalculateExpirationDays(expiresStr)
+	result, err := CalculateExpirationDays(expiresStr)
 
-	assert.Equal(t, defaultValue, result, "Result should be default value for invalid date format")
+	require.Error(t, err, "should return an error for unparseable date")
+	assert.Equal(t, 0, result)
 }
 
 // To verify: Modify CalculateExpirationDays to return 0
@@ -130,8 +133,9 @@ func TestCalculateExpirationDays_PastDate(t *testing.T) {
 	pastDate := time.Now().AddDate(0, 0, -10).UTC()
 	expiresStr := pastDate.Format(time.RFC3339)
 
-	result := CalculateExpirationDays(expiresStr)
+	result, err := CalculateExpirationDays(expiresStr)
 
+	require.NoError(t, err)
 	assert.GreaterOrEqual(t, result, 1, "Result should be at least 1 day for past dates")
 }
 
@@ -141,8 +145,9 @@ func TestCalculateExpirationDays_ZeroDays(t *testing.T) {
 	now := time.Now().UTC()
 	expiresStr := now.Format(time.RFC3339)
 
-	result := CalculateExpirationDays(expiresStr)
+	result, err := CalculateExpirationDays(expiresStr)
 
+	require.NoError(t, err)
 	assert.GreaterOrEqual(t, result, 1, "Result should be at least 1 day even when calculated as 0")
 }
 


### PR DESCRIPTION
## v1.5.16

### Security (TUF)

- Fixed snapshot lock key inconsistency that allowed concurrent artifact publish and force-online update to race and silently discard each other's snapshot changes.
- Fixed silent verification skip in `PostMetadataSign` targets path: S3/unmarshal failures now surface as errors instead of being swallowed, preventing unverified metadata from advancing.
- Fixed trusted metadata loaded from S3 without expiration check; expired metadata is now rejected before use.
- Fixed root rotation staging that used fragile error string matching to detect wrong-version vs bad-signature failures.
- Fixed `PostMetadataSign` Redis writes silently ignored on staging paths; errors are now propagated.
- Fixed `loadTrustedRootMetadataFromS3` using raw `json.Unmarshal` instead of the library's `FromFile`; root is now loaded through the verified library path.

### Fixes (TUF)

- Fixed snapshot `MetaFile` entries omitting hashes; snapshot now includes `sha256` hash and length for all referenced metadata files.
- Fixed missing root signature verification in the `thresholdReached` targets signing path.
- Fixed `GetConfig` returning only the first custom role expiration due to a loop variable bug.
- Fixed `RemoveArtifacts` loading root by hardcoded version 1 instead of the latest version.
- Fixed duplicate signing logic in `removeArtifactsFromDelegatedRole`.
- Fixed MongoDB artifact status updated before TUF operation succeeds; status is now written only after a successful TUF commit.
- Fixed temporary directories created in `cwd` instead of system temp.
- Fixed `HelperGetPathForTarget` panicking on `os.Getwd()` failure; returns error instead.
- Fixed task records stored in Redis with no TTL.
- Fixed `CalculateExpirationDays` silently returning 365 on parse failure; returns error instead.
- Removed unused `ctx context.Context` parameter from delegation helpers.

### Improvements (TUF)

- Added `appName` validation to reject characters that could cause Redis key collisions or S3 path injection.
- Replaced `KEYS` with `SCAN` in `GetMetadataSign` to avoid blocking Redis on large keyspaces.
- Fixed `GetConfig` loop and `PutConfig` to respect online/offline mode for targets expiration.
- Removed dead code: `GetBootstrapLocks`, `bootstrap()`, `bootstrapFinalize()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Hardened TUF verification, root rotation and trusted-metadata checks; better handling of expired/invalid metadata.

* **Bug Fixes**
  * Prevented partial deletions after metadata failures; clearer bootstrap/recovery conflict responses and consistent snapshot/timestamp hashes.

* **Improvements**
  * App-name validation; replaced costly Redis key listing with scans; per-app snapshot locks; use system temp dirs; task status TTLs; refined targets online handling.

* **Tests**
  * New regression and signature-verification tests; expanded bootstrap and metadata coverage.

* **Documentation**
  * Added v1.5.16 changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->